### PR TITLE
feat: implement video playback page and navigation from search results

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-player": "^3.3.1",
         "react-router-dom": "^7.7.1"
       },
       "devDependencies": {
@@ -927,6 +928,74 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mux/mux-data-google-ima": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@mux/mux-data-google-ima/-/mux-data-google-ima-0.2.8.tgz",
+      "integrity": "sha512-0ZEkHdcZ6bS8QtcjFcoJeZxJTpX7qRIledf4q1trMWPznugvtajCjCM2kieK/pzkZj1JM6liDRFs1PJSfVUs2A==",
+      "license": "MIT",
+      "dependencies": {
+        "mux-embed": "5.9.0"
+      }
+    },
+    "node_modules/@mux/mux-player": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player/-/mux-player-3.5.2.tgz",
+      "integrity": "sha512-/0q+9ecP/CnVbA38YVwzy/n6BBsl3NFCfsiePzJSCSItYF4Dpx/GdYydtAt4GTbx6pXJIInPaXKaCLmb4HK2ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-video": "0.26.1",
+        "@mux/playback-core": "0.30.1",
+        "media-chrome": "~4.11.1",
+        "player.style": "^0.1.9"
+      }
+    },
+    "node_modules/@mux/mux-player-react": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@mux/mux-player-react/-/mux-player-react-3.5.2.tgz",
+      "integrity": "sha512-K78wNz0xyIgo4O0WAG5OiGzLfB5lGrzzn0OUXRO7F2bN1Vus2mP90PZmr2+3txU2njeR0kAXOccTAIfh9PeSsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player": "3.5.2",
+        "@mux/playback-core": "0.30.1",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react": "^17.0.2 || ^17.0.0-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0",
+        "react-dom": "^17.0.2 || ^17.0.2-0 || ^18 || ^18.0.0-0 || ^19 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mux/mux-video": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@mux/mux-video/-/mux-video-0.26.1.tgz",
+      "integrity": "sha512-gkMdBAgNlB4+krANZHkQFzYWjWeNsJz69y1/hnPtmNQnpvW+O7oc71OffcZrbblyibSxWMQ6MQpYmBVjXlp6sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-data-google-ima": "0.2.8",
+        "@mux/playback-core": "0.30.1",
+        "castable-video": "~1.1.10",
+        "custom-media-element": "~1.4.5",
+        "media-tracks": "~0.3.3"
+      }
+    },
+    "node_modules/@mux/playback-core": {
+      "version": "0.30.1",
+      "resolved": "https://registry.npmjs.org/@mux/playback-core/-/playback-core-0.30.1.tgz",
+      "integrity": "sha512-rnO1NE9xHDyzbAkmE6ygJYcD7cyyMt7xXqWTykxlceaoSXLjUqgp42HDio7Lcidto4x/O4FIa7ztjV2aCBCXgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hls.js": "~1.6.6",
+        "mux-embed": "^5.8.3"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1259,6 +1328,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@svta/common-media-library": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@svta/common-media-library/-/common-media-library-0.12.4.tgz",
+      "integrity": "sha512-9EuOoaNmz7JrfGwjsrD9SxF9otU5TNMnbLu1yU4BeLK0W5cDxVXXR58Z89q9u2AnHjIctscjMTYdlqQ1gojTuw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1322,7 +1397,6 @@
       "version": "19.1.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
       "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1344,6 +1418,22 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vercel/edge": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.2.2.tgz",
+      "integrity": "sha512-1+y+f6rk0Yc9ss9bRDgz/gdpLimwoRteKHhrcgHvEpjbP1nyT3ByqEMWm2BTcpIO5UtDmIFXc8zdq4LR190PDA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@vimeo/player": {
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/@vimeo/player/-/player-2.29.0.tgz",
+      "integrity": "sha512-9JjvjeqUndb9otCCFd0/+2ESsLk7VkDE6sxOBy9iy2ukezuQbplVRi+g9g59yAurKofbmTi/KcKxBGO/22zWRw==",
+      "license": "MIT",
+      "dependencies": {
+        "native-promise-only": "0.8.1",
+        "weakmap-polyfill": "2.0.4"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1669,6 +1759,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bcp-47": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+      "integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-match": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/bcp-47-match/-/bcp-47-match-2.0.3.tgz",
+      "integrity": "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/bcp-47-normalize": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bcp-47-normalize/-/bcp-47-normalize-2.3.0.tgz",
+      "integrity": "sha512-8I/wfzqQvttUFz7HVJgIZ7+dj3vUaIyIxYXaTRP1YWoSDfzt6TUmxaKZeuXR62qBmYr+nvuWINFRl6pZ5DlN4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "bcp-47": "^2.0.0",
+        "bcp-47-match": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1794,6 +1923,24 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/castable-video": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/castable-video/-/castable-video-1.1.10.tgz",
+      "integrity": "sha512-/T1I0A4VG769wTEZ8gWuy1Crn9saAfRTd1UYTb8xbOPlN78+zOi/1nU2dD5koNkfE5VWvgabkIqrGKmyNXOjSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "~1.4.5"
+      }
+    },
+    "node_modules/ce-la-react": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ce-la-react/-/ce-la-react-0.3.1.tgz",
+      "integrity": "sha512-g0YwpZDPIwTwFumGTzNHcgJA6VhFfFCJkSNdUdC04br2UfU+56JDrJrJva3FZ7MToB4NDHAFBiPE/PZdNl1mQA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "react": ">=17.0.0"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1810,6 +1957,18 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/cloudflare-video-element": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/cloudflare-video-element/-/cloudflare-video-element-1.3.3.tgz",
+      "integrity": "sha512-qrHzwLmUhisoIuEoKc7iBbdzBNj2Pi7ThHslU/9U/6PY9DEvo4mh/U+w7OVuzXT9ks7ZXfARvDBfPAaMGF/hIg==",
+      "license": "MIT"
+    },
+    "node_modules/codem-isoboxer": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/codem-isoboxer/-/codem-isoboxer-0.3.10.tgz",
+      "integrity": "sha512-eNk3TRV+xQMJ1PEj0FQGY8KD4m0GPxT487XJ+Iftm7mVa9WpPFDMWqPt+46buiP5j5Wzqe5oMIhqBcAeKfygSA==",
+      "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -1880,7 +2039,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/custom-media-element": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/custom-media-element/-/custom-media-element-1.4.5.tgz",
+      "integrity": "sha512-cjrsQufETwxjvwZbYbKBCJNvmQ2++G9AvT45zDi7NXL9k2PdVcs2h0jQz96J6G4TMKRCcEsoJ+QTgQD00Igtjw==",
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -1889,6 +2053,34 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/dash-video-element": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/dash-video-element/-/dash-video-element-0.1.6.tgz",
+      "integrity": "sha512-4gHShaQjcFv6diX5EzB6qAdUGKlIUGGZY8J8yp2pQkWqR0jX4c6plYy0cFraN7mr0DZINe8ujDN1fssDYxJjcg==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.5",
+        "dashjs": "^5.0.3"
+      }
+    },
+    "node_modules/dashjs": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/dashjs/-/dashjs-5.0.3.tgz",
+      "integrity": "sha512-TXndNnCUjFjF2nYBxDVba+hWRpVkadkQ8flLp7kHkem+5+wZTfRShJCnVkPUosmjS0YPE9fVNLbYPJxHBeQZvA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@svta/common-media-library": "^0.12.4",
+        "bcp-47-match": "^2.0.3",
+        "bcp-47-normalize": "^2.3.0",
+        "codem-isoboxer": "0.3.10",
+        "fast-deep-equal": "3.1.3",
+        "html-entities": "^2.5.2",
+        "imsc": "^1.1.5",
+        "localforage": "^1.10.0",
+        "path-browserify": "^1.0.1",
+        "ua-parser-js": "^1.0.37"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -2752,7 +2944,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -3171,6 +3362,39 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hls-video-element": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/hls-video-element/-/hls-video-element-1.5.6.tgz",
+      "integrity": "sha512-KPdvSR+oBJPiCVb+m6pd2mn3rJEjNbaK8pGhSkxFI2pmyvZIeTVQrPbEO9PT/juwXHwhvCoKJnNxAuFwJG9H5A==",
+      "license": "MIT",
+      "dependencies": {
+        "custom-media-element": "^1.4.5",
+        "hls.js": "^1.6.5",
+        "media-tracks": "^0.3.3"
+      }
+    },
+    "node_modules/hls.js": {
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.8.tgz",
+      "integrity": "sha512-oifhtMNYRpB1VmzH/hWd4NXziMJ1hCeA15XG1ET4jh6u4khXsYsqqvpEFWmNWS+8J6tbsv10wYq5ZiY21HG2Gg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3180,6 +3404,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -3196,6 +3426,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imsc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/imsc/-/imsc-1.1.5.tgz",
+      "integrity": "sha512-V8je+CGkcvGhgl2C1GlhqFFiUOIEdwXbXLiu1Fcubvvbo+g9inauqT3l0pNYXGoLPBj3jxtZz9t+wCopMkwadQ==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "sax": "1.2.1"
       }
     },
     "node_modules/imurmurhash": {
@@ -3240,6 +3479,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3375,6 +3638,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-extglob": {
@@ -3669,7 +3942,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3792,6 +4064,24 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3819,7 +4109,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3847,6 +4136,22 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/media-chrome": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/media-chrome/-/media-chrome-4.11.1.tgz",
+      "integrity": "sha512-+2niDc4qOwlpFAjwxg1OaizK/zKV6y7QqGm4nBFEVlSaG0ZBgOmfc4IXAPiirZqAlZGaFFUaMqCl1SpGU0/naA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vercel/edge": "^1.2.1",
+        "ce-la-react": "^0.3.0"
+      }
+    },
+    "node_modules/media-tracks": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/media-tracks/-/media-tracks-0.3.3.tgz",
+      "integrity": "sha512-9P2FuUHnZZ3iji+2RQk7Zkh5AmZTnOG5fODACnjhCVveX1McY3jmCRHofIEI+yTBqplz7LXy48c7fQ3Uigp88w==",
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -3878,6 +4183,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/mux-embed": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/mux-embed/-/mux-embed-5.9.0.tgz",
+      "integrity": "sha512-wmunL3uoPhma/tWy8PrDPZkvJpXvSFBwbD3KkC4PG8Ztjfb1X3hRJwGUAQyRz7z99b/ovLm2UTTitrkvStjH4w==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -3897,6 +4208,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/native-promise-only": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+      "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3915,7 +4232,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4125,6 +4441,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4180,6 +4502,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/player.style": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/player.style/-/player.style-0.1.9.tgz",
+      "integrity": "sha512-aFmIhHMrnAP8YliFYFMnRw+5AlHqBvnqWy4vHGo2kFxlC+XjmTXqgg62qSxlE8ubAY83c0ViEZGYglSJi6mGCA==",
+      "license": "MIT",
+      "workspaces": [
+        ".",
+        "site",
+        "examples/*",
+        "scripts/*",
+        "themes/*"
+      ],
+      "dependencies": {
+        "media-chrome": "~4.11.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -4251,7 +4589,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -4315,8 +4652,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-player": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-3.3.1.tgz",
+      "integrity": "sha512-wE/xLloneXZ1keelFCaNeIFVNUp4/7YoUjfHjwF945aQzsbDKiIB0LQuCchGL+la0Y1IybxnR0R6Cm3AiqInMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mux/mux-player-react": "^3.5.1",
+        "cloudflare-video-element": "^1.3.3",
+        "dash-video-element": "^0.1.6",
+        "hls-video-element": "^1.5.6",
+        "spotify-audio-element": "^1.0.2",
+        "tiktok-video-element": "^0.1.0",
+        "twitch-video-element": "^0.1.2",
+        "vimeo-video-element": "^1.5.3",
+        "wistia-video-element": "^1.3.3",
+        "youtube-video-element": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18 || ^19",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4588,6 +4947,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
+      "license": "ISC"
+    },
     "node_modules/scheduler": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
@@ -4768,6 +5133,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spotify-audio-element": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/spotify-audio-element/-/spotify-audio-element-1.0.2.tgz",
+      "integrity": "sha512-YEovyyeJTJMzdSVqFw/Fx19e1gdcD4bmZZ/fWS0Ji58KTpvAT2rophgK87ocqpy6eJNSmIHikhgbRjGWumgZew==",
+      "license": "MIT"
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -4931,6 +5302,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/super-media-element": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/super-media-element/-/super-media-element-1.4.2.tgz",
+      "integrity": "sha512-9pP/CVNp4NF2MNlRzLwQkjiTgKKe9WYXrLh9+8QokWmMxz+zt2mf1utkWLco26IuA3AfVcTb//qtlTIjY3VHxA==",
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4962,6 +5339,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tiktok-video-element": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tiktok-video-element/-/tiktok-video-element-0.1.0.tgz",
+      "integrity": "sha512-PVWUlpDdQ/LPXi7x4/furfD7Xh1L72CgkGCaMsZBIjvxucMGm1DDPJdM9IhWBFfo6tuR4cYVO/v596r6GG/lvQ==",
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
@@ -5006,6 +5389,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/twitch-video-element": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/twitch-video-element/-/twitch-video-element-0.1.2.tgz",
+      "integrity": "sha512-/up4KiWiTYiav+CUo+/DbV8JhP4COwEKSo8h1H/Zft/5NzZ/ZiIQ48h7erFKvwzalN0GfkEGGIfwIzAO0h7FHQ==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5111,6 +5500,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.40",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.40.tgz",
+      "integrity": "sha512-z6PJ8Lml+v3ichVojCiB8toQJBuwR42ySM4ezjXIqXK3M0HczmKQ3LF4rhU55PfD99KEEXQG6yb7iOMyvYuHew==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -5169,6 +5584,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vimeo-video-element": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/vimeo-video-element/-/vimeo-video-element-1.5.3.tgz",
+      "integrity": "sha512-OQWyGS9nTouMqfRJyvmAm/n6IRhZ7x3EfPAef+Q+inGBeHa3SylDbtyeB/rEBd4B/T/lcYBW3rjaD9W2DRYkiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vimeo/player": "2.29.0"
       }
     },
     "node_modules/vite": {
@@ -5244,6 +5668,15 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/weakmap-polyfill": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/weakmap-polyfill/-/weakmap-polyfill-2.0.4.tgz",
+      "integrity": "sha512-ZzxBf288iALJseijWelmECm/1x7ZwQn3sMYIkDr2VvZp7r6SEKuT8D0O9Wiq6L9Nl5mazrOMcmiZE/2NCenaxw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/which": {
@@ -5351,6 +5784,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/wistia-video-element": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/wistia-video-element/-/wistia-video-element-1.3.3.tgz",
+      "integrity": "sha512-ZVC8HH8uV3mQGcSz10MACLDalao/0YdVverNN4GNFsOXiumfqSiZnRVc8WZEywgVckBkR7+yerQYESYPDzvTfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "super-media-element": "~1.4.2"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5387,6 +5829,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/youtube-video-element": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/youtube-video-element/-/youtube-video-element-1.6.1.tgz",
+      "integrity": "sha512-FDRgXlPxpe1bh6HlhL6GfJVcvVNaZKCcLEZ90X1G3Iu+z2g2cIhm2OWj9abPZq1Zqit6SY7Gwh13H9g7acoBnQ==",
+      "license": "MIT"
     }
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-player": "^3.3.1",
     "react-router-dom": "^7.7.1"
   },
   "devDependencies": {

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -1,16 +1,20 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import "./App.css";
 import Header from "./components/Header";
+import ScrollToTop from "./components/ScrollToTop";
 import Homepage from "./pages/HomePage";
 import SearchResultPage from "./pages/SearchResultPage";
+import VideoDetailPage from "./pages/VideoDetailPage";
 
 const App = () => {
   return (
     <Router>
       <Header />
+      <ScrollToTop />
       <Routes>
         <Route path="/" element={<Homepage />} />
         <Route path="/search" element={<SearchResultPage />} />
+        <Route path="/video/:id" element={<VideoDetailPage />} />
       </Routes>
     </Router>
   );

--- a/front/src/components/ScrollToTop.jsx
+++ b/front/src/components/ScrollToTop.jsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import {useLocation} from "react-router-dom";
+
+const ScrollToTop = () => {
+  const {pathname} = useLocation();
+
+  useEffect(() => {
+    if ("scrollRestoration" in window.history){
+      window.history.scrollRestoration = "manual";
+    }
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop;

--- a/front/src/components/VideoItem.jsx
+++ b/front/src/components/VideoItem.jsx
@@ -1,9 +1,11 @@
-const VideoItem = ({video, channel}) => {
+const VideoItem = ({video, channel, onClick}) => {
   return (
     <div>
       <img
         src={video.thumbnail}
         alt={video.title}
+        style={{cursor: "pointer"}}
+        onClick={onClick}
       />
       <p>{video.title}</p>
       <p>チャンネル名：{channel?.title || "不明"}</p>

--- a/front/src/pages/SearchResultPage.jsx
+++ b/front/src/pages/SearchResultPage.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useSearchParams } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import fetchYoutubeVideos from "../utils/fetchYoutubeVideos";
 import VideoItem from "../components/VideoItem";
 
@@ -8,6 +8,7 @@ const SearchResultPage = () => {
   const [channels, setChannels] = useState([]);
   const [params] = useSearchParams();
   const query = params.get("q");
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (!query) return;
@@ -20,12 +21,14 @@ const SearchResultPage = () => {
       setVideos(parsed.videos || []);
       setChannels(parsed.channels || []);
       console.log("【キャッシュから取得】videos:", parsed.videos);
+      sessionStorage.setItem("lastQuery", query);
     } else {
       fetchYoutubeVideos(query).then((data) => {
         setVideos(data.videos || []);
         setChannels(data.channels || []);
         console.log("【APIから取得】videos:", data.videos);
         sessionStorage.setItem(cacheKey, JSON.stringify(data));
+        sessionStorage.setItem("lastQuery", query);
       });
     }
   }, [query]);
@@ -39,6 +42,7 @@ const SearchResultPage = () => {
             key={video.id}
             video={video}
             channel={channels.find(c => c.id === video.channelId)}
+            onClick={() => navigate(`/video/${video.id}`)}
           />
         ))}
       </div>

--- a/front/src/pages/VideoDetailPage.jsx
+++ b/front/src/pages/VideoDetailPage.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom"
+import ReactPlayer from "react-player";
+import VideoItem from "../components/VideoItem";
+
+const VideoDetailPage = () => {
+  const {id} = useParams();
+  const navigate = useNavigate();
+  const [relatedVideos, setRelatedVideos] = useState([]);
+  const [channels, setChannels] = useState([]);
+
+  useEffect(() => {
+    const lastQuery = sessionStorage.getItem("lastQuery");
+    if(!lastQuery) return;
+
+    const cacheKey = `searchResult:${lastQuery}`;
+    const cachedData = sessionStorage.getItem(cacheKey);
+
+    if(cachedData){
+      const parsed = JSON.parse(cachedData);
+      setRelatedVideos(parsed.videos.filter((v) => v.id !== id));
+      setChannels(parsed.channels || []);
+    }
+  }, [id]);
+
+  return(
+    <div>
+      <h2>動画再生ページ</h2>
+      <ReactPlayer
+        src={`https://www.youtube.com/watch?v=${id}`}
+        controls
+        style={{width: "100%", aspectRatio: "16/9"}}
+      />
+      <h3>関連動画</h3>
+      <div>
+        {relatedVideos.map((video) => (
+          <VideoItem
+            key={video.id}
+            video={video}
+            channel={channels.find(c => c.id === video.channelId)}
+            onClick={() => navigate(`/video/${video.id}`)}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default VideoDetailPage;


### PR DESCRIPTION
## 概要
YouTubeの検索結果一覧から動画を選択し、詳細ページで再生できるよう変更。  
動画再生には `react-player` を使用。
関連動画も同一ページ内に表示され、クリックで遷移可能。

## 変更内容

### パッケージ追加
- `react-player` をインストール（動画の埋め込み用）

###  機能追加
- `VideoDetailPage.jsx` を新規作成し、以下を実装：
  - 動画ID（URLパラメータ）をもとに対象の動画をiframeで再生
  - `sessionStorage` から `lastQuery` を取得し、関連動画を表示
- `VideoItem` の `onClick` によって `/video/:id` に遷移するように設定
- `SearchResultPage` から動画を選択可能に
- 関連動画も再生できるように、`VideoDetailPage` 内から他の動画へ遷移対応
- ページ遷移時にスクロール位置をリセットする `ScrollToTop` を追加

### ルーティング追加
- `App.jsx` に `/video/:id` のルートを追加

## 動作確認
- 検索結果から任意の動画をクリック → 動画詳細ページへ遷移
- 遷移後、対象の動画が再生される（ReactPlayerを使用）
- 同ページ内に関連動画一覧が表示され、クリックで再遷移可能
- ページ遷移時にスクロールがトップに戻ることを確認
