### PR TITLE
feat: add Google Maps display to video detail page with responsive layout

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -11,6 +11,7 @@
         "@vis.gl/react-google-maps": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-modal-sheet": "^4.4.0",
         "react-player": "^3.3.1",
         "react-router-dom": "^7.7.1"
       },
@@ -3074,6 +3075,34 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4197,6 +4226,50 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.23.12.tgz",
+      "integrity": "sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "framer-motion": "^12.23.12",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4674,6 +4747,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-modal-sheet": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/react-modal-sheet/-/react-modal-sheet-4.4.0.tgz",
+      "integrity": "sha512-ub42vR7iwjdM/2Zl6uZoH5M5Dcb6KTuVaOQ+uQCIlo10SdlYAhksb6u3eIFSLohFrX5q03rgFnR6Y0PKhjjl/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "motion": ">=11",
+        "react": ">=16"
+      }
     },
     "node_modules/react-player": {
       "version": "3.3.1",
@@ -5410,6 +5496,13 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/twitch-video-element": {
       "version": "0.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -13,6 +13,7 @@
     "@vis.gl/react-google-maps": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-modal-sheet": "^4.4.0",
     "react-player": "^3.3.1",
     "react-router-dom": "^7.7.1"
   },

--- a/front/src/components/VideoPlayerWrapper.jsx
+++ b/front/src/components/VideoPlayerWrapper.jsx
@@ -1,0 +1,17 @@
+import ReactPlayer from "react-player";
+
+const VideoPlayerWrapper = ({ videoId }) => {
+  return (
+    <div style={{ position: "relative", paddingTop: "56.25%", width: "100%" }}>
+      <ReactPlayer
+        src={`https://www.youtube.com/watch?v=${videoId}`}
+        controls
+        width="100%"
+        height="100%"
+        style={{ position: "absolute", top: 0, left: 0 }}
+      />
+    </div>
+  );
+};
+
+export default VideoPlayerWrapper;

--- a/front/src/hooks/useIsMobile.js
+++ b/front/src/hooks/useIsMobile.js
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react"
+
+const useIsMobile = (breakpoint = 768) => {
+  const [isMobile, setIsMobile] = useState(window.innerWidth < breakpoint);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < breakpoint);
+    };
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, [breakpoint]);
+
+  return isMobile;
+}
+
+export default useIsMobile;

--- a/front/src/pages/MapPreview.jsx
+++ b/front/src/pages/MapPreview.jsx
@@ -1,0 +1,26 @@
+import {AdvancedMarker, APIProvider, Map} from '@vis.gl/react-google-maps';
+import { useEffect, useState } from 'react';
+
+const MapPreview = ({position}) => {
+  const [shouldRenderMap, setShouldRednerMap] = useState(false);
+
+  useEffect(() => {
+    setShouldRednerMap(true);
+  }, []);
+  return (
+    <APIProvider apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}>
+      {shouldRenderMap && (
+        <Map
+          defaultCenter={position}
+          defaultZoom={14}
+          mapId={import.meta.env.VITE_GOOGLE_MAP_ID}
+          style={{ height: "100%", width: "100%" }}
+        >
+          <AdvancedMarker position={position}/>
+        </Map>
+      )}
+    </APIProvider>
+  )
+}
+
+export default MapPreview;

--- a/front/src/pages/VideoDetailPage.jsx
+++ b/front/src/pages/VideoDetailPage.jsx
@@ -1,13 +1,21 @@
 import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom"
-import ReactPlayer from "react-player";
+import VideoPlayerWrapper from "../components/VideoPlayerWrapper";
 import VideoItem from "../components/VideoItem";
+import MapPreview from "./MapPreview";
+import useIsMobile from "../hooks/useIsMobile";
+import {Sheet} from "react-modal-sheet";
 
 const VideoDetailPage = () => {
   const {id} = useParams();
   const navigate = useNavigate();
+  const isMobile = useIsMobile();
   const [relatedVideos, setRelatedVideos] = useState([]);
   const [channels, setChannels] = useState([]);
+  const [openSheet, setOpenSheet] = useState(false);
+  const [showMap, setShowMap] = useState(false);
+
+  const position = {lat: 35.681236, lng: 139.767125};
 
   useEffect(() => {
     const lastQuery = sessionStorage.getItem("lastQuery");
@@ -24,24 +32,51 @@ const VideoDetailPage = () => {
   }, [id]);
 
   return(
-    <div>
-      <h2>動画再生ページ</h2>
-      <ReactPlayer
-        src={`https://www.youtube.com/watch?v=${id}`}
-        controls
-        style={{width: "100%", aspectRatio: "16/9"}}
-      />
-      <h3>関連動画</h3>
-      <div>
-        {relatedVideos.map((video) => (
-          <VideoItem
-            key={video.id}
-            video={video}
-            channel={channels.find(c => c.id === video.channelId)}
-            onClick={() => navigate(`/video/${video.id}`)}
-          />
-        ))}
+    <div style={{display: "flex", flexDirection: isMobile ? "column" : "row", height: "100vh" }}>
+      <div style={{flex: 1, display: "flex", flexDirection: "column"}}>
+        <h2>動画再生ページ</h2>
+        <div style={{flex: "0 0 300px"}}>
+          <VideoPlayerWrapper videoId={id}/>
+        </div>
+        {isMobile && (
+          <>
+            <button onClick={() => {
+              setOpenSheet(true);
+              setShowMap(true);
+            }}>
+              マップを開く
+            </button>
+            <Sheet isOpen={openSheet} onClose={() => setOpenSheet(false)}>
+              <Sheet.Container>
+                <Sheet.Header />
+                <Sheet.Content>
+                  <div style={{display: showMap ? "block" : "none", height: "300px"}}>
+                    <MapPreview position={position}/>
+                  </div>
+                </Sheet.Content>
+              </Sheet.Container>
+              <Sheet.Backdrop />
+            </Sheet>
+          </>
+        )}
+        <h3>関連動画</h3>
+        <div style={{flex: 1, overflowY: "auto"}}>
+          {relatedVideos.map((video) => (
+            <VideoItem
+              key={video.id}
+              video={video}
+              channel={channels.find(c => c.id === video.channelId)}
+              onClick={() => navigate(`/video/${video.id}`)}
+            />
+          ))}
+        </div>
       </div>
+
+      {!isMobile && (
+        <div style={{width: "400px", marginLeft: "16px", height: "100vh"}}>
+          <MapPreview position={position} />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## 概要
動画詳細ページに Google Maps を表示する機能を追加。  
モバイルではモーダル表示、デスクトップでは右側に常設表示されるように
マップの表示には `@vis.gl/react-google-maps`、モーダルには `react-modal-sheet` を使用。

## 変更内容

### Map表示
- `MapPreview.jsx` を新規作成し、Google Maps の描画処理をコンポーネント化
- APIProvider と Map コンポーネントの再レンダリング制御のため `shouldRenderMap` を導入

### 動画再生ページ対応
- `VideoDetailPage.jsx` にて以下を追加：
  - モバイル時：ボタン押下でモーダルを表示し、Map を展開（`react-modal-sheet`使用）
  - PC時：右側に常設表示（flexレイアウトで分割）
  - 再生プレイヤーのラッパー `VideoPlayerWrapper.jsx` を追加し、16:9の比率で表示

### フック追加
- `useIsMobile.js`：画面幅によってモバイル判定するカスタムフックを追加（デフォルト768px）

### パッケージ追加
- `react-modal-sheet` を導入し、スライドイン型のモバイルモーダルを実装

## 動作確認
- `/video/:id` にアクセス
- モバイル：
  - 「マップを開く」ボタンでモーダルがスライド表示
  - マップが正常に表示され、モーダルの開閉が機能する
- デスクトップ：
  - 画面右側にマップが常時表示されている
- 表示にエラーが出ないことを確認
