### PR TITLE
fix: trigger API call only after Japanese input composition ends

### DIFF
--- a/front/src/hooks/useAutocompleteSuggestions.js
+++ b/front/src/hooks/useAutocompleteSuggestions.js
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 import { useMapsLibrary } from "@vis.gl/react-google-maps";
 
-export function useAutocompleteSuggestions(inputValue) {
+export function useAutocompleteSuggestions(searchValue) {
   const placesLib = useMapsLibrary("places");
   const sessionTokenRef = useRef(null);
   const [suggestions, setSuggestions] = useState([]);
 
   useEffect(() => {
-    if (!placesLib) return;
+    if (!placesLib || !searchValue) return;
 
     const { AutocompleteSessionToken, AutocompleteSuggestion } = placesLib;
 
@@ -15,20 +15,20 @@ export function useAutocompleteSuggestions(inputValue) {
       sessionTokenRef.current = new AutocompleteSessionToken();
     }
 
-    if (!inputValue) {
+    if (!searchValue) {
       setSuggestions([]);
       return;
     }
 
     const request = {
-      input: inputValue,
+      input: searchValue,
       sessionToken: sessionTokenRef.current,
     };
 
     AutocompleteSuggestion.fetchAutocompleteSuggestions(request).then((res) => {
       setSuggestions(res.suggestions);
     });
-  }, [inputValue, placesLib]);
+  }, [searchValue, placesLib]);
 
   return {
     suggestions,


### PR DESCRIPTION
## 概要
日本語IMEでの入力中に発生していた不要なAPIリクエストを抑制し、Places APIの利用回数を削減。

## 変更内容

`PlaceAutocomplete.jsx`
- isComposingフラグを追加し、日本語入力（IME変換）中かどうかを判定
- 日本語入力確定時（onCompositionEnd）のみAPIリクエストを実行
- 英語などIMEを使用しない入力の場合はEnterキー押下で即時リクエストを実行

`useAutocompleteSuggestions.js`
- セッショントークンの再利用処理を維持
- searchValueが空の場合はサジェストをクリア