### PR TITLE
fix: disable modal drag while interacting with the map

### DIFF
--- a/front/src/components/layouts/MobileLayout.jsx
+++ b/front/src/components/layouts/MobileLayout.jsx
@@ -13,6 +13,8 @@ const MobileLayout = ({ id, relatedVideos, channels }) => {
   const [isMapOpen, setIsMapOpen] = useState(false);
   const [position, setPosition] = useState({ lat: 35.681236, lng: 139.767125 });
 
+  const [isDraggingMap, setIsDraggingMap] = useState(false);
+
   const handleSelectPlace = (place) => {
     const lat = typeof place.location?.lat === "function" ? place.location.lat() : place.location?.lat;
     const lng = typeof place.location?.lng === "function" ? place.location.lng() : place.location?.lng;
@@ -69,8 +71,20 @@ const MobileLayout = ({ id, relatedVideos, channels }) => {
           <Sheet.Header>
             <PlaceAutocomplete onPlaceSelect={handleSelectPlace} />
           </Sheet.Header>
-          <Sheet.Content>
-            {isMapOpen && <MapPreview position={position} />}
+          <Sheet.Content disableDrag={isDraggingMap}>
+            {isMapOpen && (
+              <div
+                onTouchStart={() => setIsDraggingMap(true)}
+                onTouchEnd={() => setIsDraggingMap(false)}
+                onMouseEnter={() => setIsDraggingMap(true)}
+                onMouseLeave={() => setIsDraggingMap(false)}
+              >
+                <MapPreview
+                  key={`${position.lat}-${position.lng}`}
+                  position={position}
+                />
+              </div>
+            )}
           </Sheet.Content>
         </Sheet.Container>
         <Sheet.Backdrop onTap={() => setIsSheetOpen(false)} />


### PR DESCRIPTION
## 概要
モーダル内のGoogleマップを操作している最中に、モーダル全体がドラッグされてしまう不具合を修正しました。

## 変更内容
`MobileLayout.jsx`
- 地図エリアでのタッチ・マウス操作中は disableDrag を有効化し、モーダルのスワイプ操作を無効化