### PR TITLE
feat: implement POST /api/bookmarks with model associations and validations

### DIFF
--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -1,0 +1,41 @@
+class Api::BookmarksController < ApplicationController
+  def create
+    ActiveRecord::Base.transaction do
+      vv = VideoView.find_or_initialize_by(youtube_video_id: vv_params[:youtube_video_id])
+      vv.assign_attributes(
+        title: vv_params[:title],
+        thumbnail_url: vv_params[:thumbnail_url],
+        search_history_id: vv_params[:search_history_id]
+      )
+      vv.save!
+
+      place = Place.find_or_initialize_by(place_id: place_params[:place_id])
+      place.assign_attributes(
+        name: place_params[:name],
+        address: place_params[:address],
+        latitude: place_params[:latitude],
+        longitude: place_params[:longitude]
+      )
+      place.save!
+
+      VideoViewPlace.find_or_create_by!(video_view: vv, place: place)
+
+      render json: {
+        video_view: { id: vv.id, youtube_video_id: vv.youtube_video_id },
+        place: { id: place.id, place_id: place.place_id, name: place.name },
+        linked: true
+      }, status: :created
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  private
+  def vv_params
+    params.require(:video_view).permit(:youtube_video_id, :title, :thumbnail_url, :search_history_id)
+  end
+
+  def place_params
+    params.require(:place).permit(:place_id, :name, :address, :latitude, :longitude)
+  end
+end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  include ActionController::RequestForgeryProtection
+  protect_from_forgery with: :null_session
 end

--- a/api/app/models/place.rb
+++ b/api/app/models/place.rb
@@ -1,0 +1,7 @@
+class Place < ApplicationRecord
+  has_many :video_view_places, dependent: :destroy
+  has_many :video_views, through: :video_view_places
+
+  validates :place_id, presence: true, uniqueness: true
+  validates :name, :address, :latitude, :longitude, presence: true
+end

--- a/api/app/models/video_view.rb
+++ b/api/app/models/video_view.rb
@@ -1,0 +1,7 @@
+class VideoView < ApplicationRecord
+  has_many :video_view_places, dependent: :destroy
+  has_many :places, through: :video_view_places
+
+  validates :youtube_video_id, presence: true, uniqueness: true
+  validates :title, :thumbnail_url, presence: true
+end

--- a/api/app/models/video_view_place.rb
+++ b/api/app/models/video_view_place.rb
@@ -1,0 +1,4 @@
+class VideoViewPlace < ApplicationRecord
+  belongs_to :video_view
+  belongs_to :place
+end

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -1,16 +1,20 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV['MYSQL_USER'] %>
-  password: <%= ENV['MYSQL_PASSWORD'] %>
+  collation: utf8mb4_0900_ai_ci
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
   host: db
+  username: root
+  password: <%= ENV['MYSQL_ROOT_PASSWORD'] %>
+  port: 3306
 
 development:
   <<: *default
   database: <%= ENV['MYSQL_DATABASE'] %>
+
 test:
   <<: *default
-  database: <%= ENV['MYSQL_DATABASE'] %>
+  database: <%= ENV['MYSQL_TEST_DATABASE'] %>
+
 production:
   url: <%= ENV['DATABASE_URL'] %>

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,10 +1,5 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  namespace :api do
+    resources :bookmarks, only: :create
+  end
 end

--- a/api/db/migrate/20250810091449_create_places.rb
+++ b/api/db/migrate/20250810091449_create_places.rb
@@ -1,0 +1,14 @@
+class CreatePlaces < ActiveRecord::Migration[8.0]
+  def change
+    create_table :places do |t|
+      t.string :name, null: false
+      t.string :address, null: false
+      t.decimal :latitude, precision: 10, scale: 6, null: false
+      t.decimal :longitude, precision: 10, scale: 6, null: false
+      t.string :place_id, null: false
+
+      t.timestamps
+    end
+    add_index :places, :place_id, unique: true
+  end
+end

--- a/api/db/migrate/20250810091942_create_video_views.rb
+++ b/api/db/migrate/20250810091942_create_video_views.rb
@@ -1,0 +1,14 @@
+class CreateVideoViews < ActiveRecord::Migration[8.0]
+  def change
+    create_table :video_views do |t|
+      t.string :youtube_video_id, null: false
+      t.string :title, null: false
+      t.string :thumbnail_url, null: false
+      # t.references :search_history, foreign_key: true
+      t.bigint :search_history_id, null: true
+
+      t.timestamps
+    end
+    add_index :video_views, :youtube_video_id, unique: true
+  end
+end

--- a/api/db/migrate/20250810092028_create_video_view_places.rb
+++ b/api/db/migrate/20250810092028_create_video_view_places.rb
@@ -1,0 +1,11 @@
+class CreateVideoViewPlaces < ActiveRecord::Migration[8.0]
+  def change
+    create_table :video_view_places do |t|
+      t.references :video_view, null: false, foreign_key: true
+      t.references :place, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :video_view_places, [:video_view_id, :place_id], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -1,0 +1,47 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[8.0].define(version: 2025_08_10_092028) do
+  create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "address", null: false
+    t.decimal "latitude", precision: 10, scale: 6, null: false
+    t.decimal "longitude", precision: 10, scale: 6, null: false
+    t.string "place_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["place_id"], name: "index_places_on_place_id", unique: true
+  end
+
+  create_table "video_view_places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "video_view_id", null: false
+    t.bigint "place_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["place_id"], name: "index_video_view_places_on_place_id"
+    t.index ["video_view_id", "place_id"], name: "index_video_view_places_on_video_view_id_and_place_id", unique: true
+    t.index ["video_view_id"], name: "index_video_view_places_on_video_view_id"
+  end
+
+  create_table "video_views", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "youtube_video_id", null: false
+    t.string "title", null: false
+    t.string "thumbnail_url", null: false
+    t.bigint "search_history_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["youtube_video_id"], name: "index_video_views_on_youtube_video_id", unique: true
+  end
+
+  add_foreign_key "video_view_places", "places"
+  add_foreign_key "video_view_places", "video_views"
+end

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,7 +12,6 @@ services:
       - db
     environment:
       RAILS_ENV: development
-      DATABASE_URL: ${DATABASE_URL}
     stdin_open: true
     tty: true
     env_file:
@@ -34,6 +33,7 @@ services:
       - 4306:3306
     volumes:
       - mysql-data:/var/lib/mysql
+      - ./mysql/conf.d/my.cnf:/etc/mysql/conf.d/my.cnf
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
       MYSQL_DATABASE: ${MYSQL_DATABASE}

--- a/mysql/conf.d/my.cnf
+++ b/mysql/conf.d/my.cnf
@@ -1,0 +1,9 @@
+[mysqld]
+character-set-server = utf8mb4
+collation-server = utf8mb4_unicode_ci
+
+[client]
+default-character-set = utf8mb4
+
+[mysql]
+default-character-set = utf8mb4


### PR DESCRIPTION
## 概要
- 3つのテーブル（video_views, places, video_view_places）のマイグレーション作成
- モデルの関連付けとバリデーションを追加
- POST /api/bookmarks エンドポイントを実装（upsert対応）
- curlコマンドでの動作確認済み
  - リクエストデータに応じてvideo_viewsとplacesを作成または更新
  - 中間テーブル video_view_places に関連を登録
- MySQLで保存内容を確認し、日本語の文字化けがないことを検証済み

## 動作確認方法
1. 以下のcurlコマンドを実行
```bash
   curl -X POST http://localhost:3000/api/bookmarks \
   -H "Content-Type: application/json" \
   -d '{
     "video_view": {
       "youtube_video_id": "y_G54SoH2xY",
       "title": "【京都VLOG】京都ひとり旅",
       "thumbnail_url": "https://i.ytimg.com/...",
       "search_history_id": null
     },
     "place": {
       "place_id": "ChIJxxxxxxxx",
       "name": "Tokyo Station",
       "address": "東京都千代田区丸の内1-9-1",
       "latitude": 35.681236,
       "longitude": 139.767125
     }
   }'
 ```
2.MySQLに接続して各テーブルにデータが登録されていることを確認
