### PR TITLE
feat(frontend): wire MapPopup to POST /api/bookmarks and persist favorites

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -47,3 +47,5 @@ group :development do
   gem "rubocop-performance", require: false
   gem "rubocop-rails", require: false
 end
+
+gem "rack-cors", "~> 3.0"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -158,6 +158,9 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.16)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -266,6 +269,7 @@ DEPENDENCIES
   debug
   mysql2 (~> 0.5)
   puma (>= 5.0)
+  rack-cors (~> 3.0)
   rails (~> 8.0.2)
   rubocop
   rubocop-performance

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -1,16 +1,14 @@
-# Be sure to restart your server when you modify this file.
+# frozen_string_literal: true
 
-# Avoid CORS issues when API is called from the frontend app.
-# Handle Cross-Origin Resource Sharing (CORS) in order to accept cross-origin Ajax requests.
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'http://localhost:5173', 'http://127.0.0.1:5173'
 
-# Read more: https://github.com/cyu/rack-cors
-
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options],
+      expose: [],
+      credentials: false,
+      max_age: 600
+  end
+end

--- a/front/src/api/bookmarks.js
+++ b/front/src/api/bookmarks.js
@@ -1,0 +1,28 @@
+export async function createBookmark({ video, place}) {
+  const base = import.meta.env.VITE_API_BASE_URL;
+  const res = await fetch(`${base}/api/bookmarks`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      video_view: {
+        youtube_video_id: video.id,
+        title: video.title,
+        thumbnail_url: video.thumbnail,
+        search_history_id: null
+      },
+      place: {
+        place_id: place.place_id,
+        name: place.name,
+        address: place.address,
+        latitude: place.latitude,
+        longitude: place.longitude
+      }
+    })
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `HTTP ${res.status}`);
+  }
+  return res.json();
+}

--- a/front/src/components/MapPreview.jsx
+++ b/front/src/components/MapPreview.jsx
@@ -1,12 +1,15 @@
+import { createBookmark } from "../api/bookmarks";
 import { Map } from "@vis.gl/react-google-maps";
 import { useState } from "react";
 import MapPopup from "./MapPopup";
 import CustomMarker from "./CustomMarker";
 
-const MapPreview = ({ position, placeName }) => {
+const MapPreview = ({ position, placeName, selectedPlace, currentVideo }) => {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [isFavorite, setIsFavorite] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
+  const [isPosting, setIsPosting] = useState(false);
+
   return (
     <div style={{ height: "400px", width: "100%", position: "relative" }}>
       <div
@@ -92,11 +95,24 @@ const MapPreview = ({ position, placeName }) => {
             <MapPopup
               title={placeName}
               message={"行きたい場所リストに追加しますか？"}
-              confirmLabel="追加する"
+              confirmLabel={isPosting? "保存中..." : "追加する"}
               cancelLabel="キャンセル"
-              onConfirm={() => {
-                setIsFavorite(true);
-                setIsPopupOpen(false);
+              onConfirm={async () => {
+                if (!selectedPlace || !currentVideo || isPosting) return;
+                try {
+                  setIsPosting(true);
+                  await createBookmark({
+                    video: currentVideo,
+                    place: selectedPlace,
+                  });
+                  setIsFavorite(true);
+                  setIsPopupOpen(false);
+                } catch (e) {
+                  console.error(e);
+                  alert("保存に失敗しました。");
+                } finally {
+                  setIsPosting(false);
+                }
               }}
               onCancel={() => setIsPopupOpen(false)}
             />

--- a/front/src/components/PlaceAutocomplete.jsx
+++ b/front/src/components/PlaceAutocomplete.jsx
@@ -32,7 +32,7 @@ const PlaceAutocomplete = ({ onPlaceSelect }) => {
 
     const place = suggestion.placePrediction.toPlace();
     await place.fetchFields({
-      fields: ["displayName", "formattedAddress", "location", "viewport"],
+      fields: ["id", "displayName", "formattedAddress", "location", "viewport"],
     });
 
     console.log("[選択されたPlaceの内容]", place);
@@ -40,7 +40,15 @@ const PlaceAutocomplete = ({ onPlaceSelect }) => {
     resetSession();
     setInputValue("");
     setSearchValue("");
-    onPlaceSelect(place);
+    const lat = typeof place.location?.lat === "function" ? place.location.lat() : place.location?.lat;
+    const lng = typeof place.location?.lng === "function" ? place.location.lng() : place.location?.lng;
+    onPlaceSelect({
+      place_id: place.id,
+      name: place.displayName,
+      address: place.formattedAddress,
+      latitude: lat,
+      longitude: lng,
+    });
   }, [onPlaceSelect, resetSession]);
 
   return (

--- a/front/src/components/layouts/MobileLayout.jsx
+++ b/front/src/components/layouts/MobileLayout.jsx
@@ -7,25 +7,23 @@ import { Sheet } from "react-modal-sheet";
 import MapSearchBar from "../MapSearchBar";
 import PlaceAutocomplete from "../PlaceAutocomplete";
 
-const MobileLayout = ({ id, relatedVideos, channels }) => {
+const MobileLayout = ({ id, relatedVideos, channels, currentVideo }) => {
   const navigate = useNavigate();
   const [isSheetOpen, setIsSheetOpen] = useState(false);
   const [isMapOpen, setIsMapOpen] = useState(false);
   const [position, setPosition] = useState({ lat: 35.681236, lng: 139.767125 });
   const [placeName, setPlaceName] = useState("");
   const [isDraggingMap, setIsDraggingMap] = useState(false);
+  const [selectedPlace, setSelectedPlace] = useState(null);
 
-  const handleSelectPlace = (place) => {
-    const lat = typeof place.location?.lat === "function" ? place.location.lat() : place.location?.lat;
-    const lng = typeof place.location?.lng === "function" ? place.location.lng() : place.location?.lng;
-
-    if (typeof lat !== "number" || typeof lng !== "number") {
-      console.warn("Invalid lat/lng:", lat, lng);
+  const handleSelectPlace = (p) => {
+    if (typeof p.latitude !== "number" || typeof p.longitude !== "number") {
+      console.warn("Invalid lat/lng:", p);
       return;
     }
-
-    setPlaceName(place.displayName || "選択した場所");
-    setPosition({ lat, lng });
+    setSelectedPlace(p);
+    setPlaceName(p.name || "選択した場所");
+    setPosition({ lat: p.latitude, lng: p.longitude });
     setIsMapOpen(true);
   };
 
@@ -84,6 +82,8 @@ const MobileLayout = ({ id, relatedVideos, channels }) => {
                   key={`${position.lat}-${position.lng}`}
                   position={position}
                   placeName={placeName}
+                  selectedPlace={selectedPlace}
+                  currentVideo={currentVideo}
                 />
               </div>
             )}

--- a/front/src/pages/VideoDetailPage.jsx
+++ b/front/src/pages/VideoDetailPage.jsx
@@ -11,6 +11,7 @@ const VideoDetailPage = () => {
 
   const [relatedVideos, setRelatedVideos] = useState([]);
   const [channels, setChannels] = useState([]);
+  const [currentVideo, setCurrentVideo] = useState(null);
   const position = { lat: 35.681236, lng: 139.767125 };
 
   useEffect(() => {
@@ -24,6 +25,8 @@ const VideoDetailPage = () => {
       const parsed = JSON.parse(cachedData);
       setRelatedVideos(parsed.videos.filter((v) => v.id !== id));
       setChannels(parsed.channels || []);
+      const me = parsed.videos.find((v) => v.id === id);
+      if (me) setCurrentVideo(me);
     }
   }, [id]);
 
@@ -38,13 +41,15 @@ const VideoDetailPage = () => {
           relatedVideos={relatedVideos}
           channels={channels}
           position={position}
+          currentVideo={currentVideo}
         />
       ) : (
         <DesktopLayout
           id={id}
           relatedVideos={relatedVideos}
           channels={channels}
-          position={position}
+            position={position}
+            currentVideo={currentVideo}
         />
       )}
     </APIProvider>


### PR DESCRIPTION
## 概要
- マップの「追加する」操作からバックエンドの POST /api/bookmarks を呼び出し、
  動画×場所の組み合わせをDBに保存できるように変更。

## 変更点
- APIヘルパーを追加（front/src/api/bookmarks.js）
  - VITE_API_BASE_URL を利用して /api/bookmarks にPOST
- PlaceAutocomplete
  - fetchFields に id/location を追加
- VideoDetailPage
  - セッションキャッシュから現在の動画情報を取得し、子コンポーネントへ受け渡し
- MobileLayout
  - PlaceAutocompleteで選択した場所を正規化してMapPreviewへ渡す
- MapPreview
  - 「追加する」クリックで createBookmark を実行し、成功時はハートを塗りつぶし
  - 送信中ラベル（"保存中..."）と簡易エラーハンドリングを追加

## 動作確認
1. `docker compose restart front`
2. 検索 → 動画詳細へ遷移
3. 場所を検索して候補を選択 → ピンをタップ → 「追加する」
4. 成功するとハートが塗りつぶし
5. 任意でDB確認  
   - `SELECT * FROM video_views;`  
   - `SELECT * FROM places;`  
   - `SELECT * FROM video_view_places;`
