### PR TITLE
Feature/bookmarks hardening

### DIFF
--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -40,11 +40,9 @@ class Api::BookmarksController < ApplicationController
     render json: { exists: !!present }
   end
 
-  def count
-    youtube_id = params.require(:youtube_video_id)
-    vv = VideoView.find_by(youtube_video_id: youtube_id)
-    cnt = vv ? vv.video_view_places.count : 0
-    render json: { count: cnt }
+  def total_count
+    total = VideoViewPlace.count
+    render json: { total_count: total }
   end
 
   private

--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -45,6 +45,13 @@ class Api::BookmarksController < ApplicationController
     render json: { total_count: total }
   end
 
+  def place_status
+    pid = params.require(:place_id)
+    place = Place.find_by(place_id: pid)
+    cnt = place ? place.video_view_places.count : 0
+    render json: { saved: cnt > 0, count: cnt }
+  end
+
   private
   def vv_params
     params.require(:video_view).permit(:youtube_video_id, :title, :thumbnail_url, :search_history_id)

--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -18,7 +18,7 @@ class Api::BookmarksController < ApplicationController
       )
       place.save!
 
-      VideoViewPlace.find_or_create_by!(video_view: vv, place: place)
+      VideoViewPlace.create_or_find_by!(video_view: vv, place: place)
 
       render json: {
         video_view: { id: vv.id, youtube_video_id: vv.youtube_video_id },
@@ -28,6 +28,23 @@ class Api::BookmarksController < ApplicationController
     end
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
+  end
+
+  def exists
+    youtube_id = params.require(:youtube_video_id)
+    place_id = params.require(:place_id)
+
+    vv = VideoView.find_by(youtube_video_id: youtube_id)
+    place = Place.find_by(place_id: place_id)
+    present = vv && place && VideoViewPlace.exists?(video_view_id: vv.id, place_id: place.id)
+    render json: { exists: !!present }
+  end
+
+  def count
+    youtube_id = params.require(:youtube_video_id)
+    vv = VideoView.find_by(youtube_video_id: youtube_id)
+    cnt = vv ? vv.video_view_places.count : 0
+    render json: { count: cnt }
   end
 
   private

--- a/api/app/models/video_view_place.rb
+++ b/api/app/models/video_view_place.rb
@@ -1,4 +1,6 @@
 class VideoViewPlace < ApplicationRecord
   belongs_to :video_view
   belongs_to :place
+
+  validates :place_id, uniqueness: { scope: :video_view_id }
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   namespace :api do
-    resources :bookmarks, only: :create
+    resources :bookmarks, only: [:create] do
+      collection do
+        get :exists
+        get :count
+      end
+    end
   end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     resources :bookmarks, only: [:create] do
       collection do
         get :exists
-        get :count
+        get :total_count
       end
     end
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
       collection do
         get :exists
         get :total_count
+        get :place_status
       end
     end
   end

--- a/front/src/api/bookmarks.js
+++ b/front/src/api/bookmarks.js
@@ -1,28 +1,28 @@
-export async function createBookmark({ video, place}) {
-  const base = import.meta.env.VITE_API_BASE_URL;
+const base = import.meta.env.VITE_API_BASE_URL || '';
+
+export async function createBookmark(payload) {
   const res = await fetch(`${base}/api/bookmarks`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      video_view: {
-        youtube_video_id: video.id,
-        title: video.title,
-        thumbnail_url: video.thumbnail,
-        search_history_id: null
-      },
-      place: {
-        place_id: place.place_id,
-        name: place.name,
-        address: place.address,
-        latitude: place.latitude,
-        longitude: place.longitude
-      }
-    })
+    body: JSON.stringify(payload),
   });
+  if (!res.ok) throw new Error(`create failed: ${res.status}`);
+  return res.json();
+}
 
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || `HTTP ${res.status}`);
-  }
+export async function existsBookmark({ youtube_video_id, place_id }) {
+  const url = new URL(`${base}/api/bookmarks/exists`);
+  url.searchParams.set('youtube_video_id', youtube_video_id);
+  url.searchParams.set('place_id', place_id);
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`exists failed: ${res.status}`);
+  return res.json();
+}
+
+export async function countBookmarks({ youtube_video_id }) {
+  const url = new URL(`${base}/api/bookmarks/count`);
+  url.searchParams.set('youtube_video_id', youtube_video_id);
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`count failed: ${res.status}`);
   return res.json();
 }

--- a/front/src/api/bookmarks.js
+++ b/front/src/api/bookmarks.js
@@ -19,10 +19,8 @@ export async function existsBookmark({ youtube_video_id, place_id }) {
   return res.json();
 }
 
-export async function countBookmarks({ youtube_video_id }) {
-  const url = new URL(`${base}/api/bookmarks/count`);
-  url.searchParams.set('youtube_video_id', youtube_video_id);
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`count failed: ${res.status}`);
+export async function totalCountBookmarks() {
+  const res = await fetch(`${base}/api/bookmarks/total_count`);
+  if (!res.ok) throw new Error("totalCountBookmarks failed");
   return res.json();
 }

--- a/front/src/api/bookmarks.js
+++ b/front/src/api/bookmarks.js
@@ -24,3 +24,11 @@ export async function totalCountBookmarks() {
   if (!res.ok) throw new Error("totalCountBookmarks failed");
   return res.json();
 }
+
+export async function placeStatus({ place_id }) {
+  const url = new URL(`${base}/api/bookmarks/place_status`);
+  url.searchParams.set('place_id', place_id);
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`placeStatus failed: ${res.status}`);
+  return res.json();
+}

--- a/front/src/components/MapPopup.jsx
+++ b/front/src/components/MapPopup.jsx
@@ -5,6 +5,7 @@ const MapPopup = ({
   onCancel,
   confirmLabel = "追加する",
   cancelLabel = "キャンセル",
+  confirmDisabled = false,
 }) => {
   return (
     <div
@@ -34,6 +35,7 @@ const MapPopup = ({
         <p style={{ fontSize: "14px", margin: "0 0 16px" }}>{message}</p>
 
         <button
+          disabled={confirmDisabled}
           style={{
             backgroundColor: "#2ca478",
             color: "white",
@@ -43,6 +45,8 @@ const MapPopup = ({
             fontSize: "14px",
             cursor: "pointer",
             marginBottom: "12px",
+            opacity: confirmDisabled ? 0.6 : 1,
+            pointerEvents: confirmDisabled ? "none": "auto",
           }}
           onClick={onConfirm}
         >

--- a/front/src/components/PlaceAutocomplete.jsx
+++ b/front/src/components/PlaceAutocomplete.jsx
@@ -35,8 +35,6 @@ const PlaceAutocomplete = ({ onPlaceSelect }) => {
       fields: ["id", "displayName", "formattedAddress", "location", "viewport"],
     });
 
-    console.log("[選択されたPlaceの内容]", place);
-
     resetSession();
     setInputValue("");
     setSearchValue("");

--- a/front/src/components/layouts/MobileLayout.jsx
+++ b/front/src/components/layouts/MobileLayout.jsx
@@ -17,13 +17,15 @@ const MobileLayout = ({ id, relatedVideos, channels, currentVideo }) => {
   const [selectedPlace, setSelectedPlace] = useState(null);
 
   const handleSelectPlace = (p) => {
-    if (typeof p.latitude !== "number" || typeof p.longitude !== "number") {
-      console.warn("Invalid lat/lng:", p);
+    const lat = Number(p.latitude);
+    const lng = Number(p.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      console.warn("Invalid lat/lng:", lat, lng);
       return;
     }
     setSelectedPlace(p);
     setPlaceName(p.name || "選択した場所");
-    setPosition({ lat: p.latitude, lng: p.longitude });
+    setPosition({ lat, lng });
     setIsMapOpen(true);
   };
 

--- a/front/src/pages/VideoDetailPage.jsx
+++ b/front/src/pages/VideoDetailPage.jsx
@@ -23,10 +23,10 @@ const VideoDetailPage = () => {
 
     if (cachedData) {
       const parsed = JSON.parse(cachedData);
+      const cur = (parsed.videos || []).find(v => v.id === id) || null;
+      setCurrentVideo(cur);
       setRelatedVideos(parsed.videos.filter((v) => v.id !== id));
       setChannels(parsed.channels || []);
-      const me = parsed.videos.find((v) => v.id === id);
-      if (me) setCurrentVideo(me);
     }
   }, [id]);
 
@@ -38,10 +38,10 @@ const VideoDetailPage = () => {
       {isMobile ? (
         <MobileLayout
           id={id}
+          currentVideo={currentVideo}
           relatedVideos={relatedVideos}
           channels={channels}
           position={position}
-          currentVideo={currentVideo}
         />
       ) : (
         <DesktopLayout


### PR DESCRIPTION
## 概要
マップの「追加する」操作から POST /api/bookmarks を呼び出し、動画 × 場所 の組み合わせを DB に保存できるように変更。
あわせてお気に入り件数のカウントを“動画単位”から“全体件数”へ統一し、マップ右上のハートアイコンを以下の仕様に変更。
- 登録件数 > 0 のとき：ハートを塗りつぶし + 件数バッジ表示
- 登録件数 = 0 のとき：ハートは線のみ（バッジ非表示）

ピン上のポップアップ（追加ボタン）やピンの塗りつぶしは、引き続き**その動画×場所の保存有無（exists）** で判定。

## 変更点
### バックエンド
- Routes
  - GET /api/bookmarks/total_count
  - GET/api/bookmarks/place_status
  - GET /api/bookmarks/count は 廃止
- Controller（Api::BookmarksController）
  - create: VideoViewPlace.create_or_find_by! に変更（同時実行でも二重登録を回避）
  - total_count
  - place_status
- Model
  - VideoViewPlace に複合一意制約（DB/モデル）済み

### フロント
- API ヘルパー（front/src/api/bookmarks.js）
  - createBookmark：payload 受け取りに統一
  - existsBookmark：動画×場所の保存有無を取得
  - totalCountBookmarks：全体件数を取得（新規）
  - placeStatus：場所が保存されているかを取得（新規）
- PlaceAutocomplete
  - fetchFields に id/location を追加、lng() を使用して緯度経度を正規化
- VideoDetailPage
  - セッションキャッシュから currentVideo を取得し、子へ受け渡し
- MobileLayout
  - PlaceAutocomplete の選択結果を正規化して MapPreview へ渡す（lat/lng の数値化を厳密化
- MapPreview
  - 初期化時に existsBookmark（動画×場所）と totalCountBookmarks（全体） を取得し UI 同期
  - 追加時は createBookmark を実行、成功時に全体件数を +1／ポップアップを閉じる
  - 件数 0 のときはバッジ非表示
  - 送信中ラベル（「保存中…」）・二重押下防止・簡易エラーハンドリング

## 動作確認
1.フロントの .env に以下を設定し再起動
```
VITE_API_BASE_URL=http://localhost:3000
```
```
docker compose restart front
```
2.画面操作
- 検索 → 動画詳細へ遷移
- 場所検索 → 候補を選択 → ピンをタップ → 「追加する」

3.期待結果
- 成功時：ポップアップが閉じる／ピン（その場所）は塗りつぶし／右上ハートの件数が増加
- 全体件数 0 のときはバッジ非表示、1 以上で表示