### PR TITLE
Feature/show place detail on favorite click

### DIFF
--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -48,8 +48,19 @@ class Api::BookmarksController < ApplicationController
   def place_status
     pid = params.require(:place_id)
     place = Place.find_by(place_id: pid)
-    cnt = place ? place.video_view_places.count : 0
-    render json: { saved: cnt > 0, count: cnt }
+
+    count = place ? place.video_view_places.count : 0
+
+    thumb = nil
+    if place && count > 0
+      vvp = place.video_view_places
+                .includes(:video_view)
+                .order(created_at: :desc)
+                .first
+      thumb = vvp&.video_view&.thumbnail_url
+    end
+
+    render json: { saved: count > 0, count: count, thumbnail_url: thumb }
   end
 
   private

--- a/front/src/components/PlaceDetailCard.jsx
+++ b/front/src/components/PlaceDetailCard.jsx
@@ -1,0 +1,146 @@
+const PlaceDetailCard = ({
+  place,
+  thumbnailUrl,
+  isSaved,
+  isSaving,
+  onAdd,
+  onRemove,
+  onAddToPlan,
+  onClose,
+}) => {
+  if (!place) return null;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: 12,
+        right: 12,
+        bottom: "calc(env(safe-area-inset-bottom, 0px) + 40px)",
+        background: "#fff",
+        borderRadius: 16,
+        boxShadow: "0 10px 24px rgba(0,0,0,.2)",
+        zIndex: 3000,
+        display: "grid",
+        gridTemplateColumns: "1fr 120px",
+        gap: 12,
+        padding: 12,
+      }}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div style={{ minWidth: 0 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+          <div
+            style={{
+              fontWeight: 700,
+              fontSize: 16,
+              overflow: "hidden",
+              whiteSpace: "nowrap",
+              textOverflow: "ellipsis",
+            }}
+            title={place.name}
+          >
+            {place.name || "場所"}
+          </div>
+          <button
+            aria-label="close"
+            onClick={onClose}
+            style={{
+              background: "#f2f2f2",
+              border: "none",
+              width: 28,
+              height: 28,
+              borderRadius: 14,
+              cursor: "pointer",
+              fontWeight: 700,
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        <div style={{ marginTop: 6, color: "#666", fontSize: 13, display: "flex", alignItems: "center", gap: 6 }}>
+          <span>🕘</span>
+          <span>—</span>
+          <span style={{ marginLeft: "auto" }}>▾</span>
+        </div>
+
+        <div style={{ marginTop: 10, display: "flex", alignItems: "center", gap: 12, flexWrap: "wrap" }}>
+          {isSaved ? (
+            <>
+              <span style={{ color: "#2CA478", fontWeight: 700 }}>追加済み</span>
+              <button
+                onClick={onRemove}
+                disabled={!onRemove}
+                style={{
+                  background: "none",
+                  border: "none",
+                  color: onRemove ? "#007aff" : "#aaa",
+                  textDecoration: "underline",
+                  cursor: onRemove ? "pointer" : "default",
+                }}
+              >
+                削除
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={onAdd}
+              disabled={isSaving}
+              style={{
+                background: "#2CA478",
+                color: "#fff",
+                border: "none",
+                padding: "8px 14px",
+                borderRadius: 999,
+                fontWeight: 700,
+                cursor: "pointer",
+                opacity: isSaving ? 0.6 : 1,
+              }}
+            >
+              {isSaving ? "保存中..." : "追加する"}
+            </button>
+          )}
+        </div>
+
+        <div style={{ marginTop: 8 }}>
+          <button
+            onClick={onAddToPlan}
+            disabled={!onAddToPlan}
+            style={{
+              background: "none",
+              border: "none",
+              color: onAddToPlan ? "#007aff" : "#aaa",
+              textDecoration: "underline",
+              cursor: onAddToPlan ? "pointer" : "default",
+              padding: 0,
+            }}
+          >
+            旅行プランに追加
+          </button>
+        </div>
+      </div>
+
+      <div
+        style={{
+          width: "100%",
+          height: 100,
+          borderRadius: 12,
+          background: "#e9e9e9",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          overflow: "hidden",
+        }}
+      >
+        {thumbnailUrl ? (
+          <img src={thumbnailUrl} alt="サムネイル" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+        ) : (
+          <span style={{ fontSize: 13, color: "#666" }}>サムネイル</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PlaceDetailCard;


### PR DESCRIPTION
## 概要
お気に入りに保存されている状態のピンをクリックした際に、場所の詳細カードを表示する機能を追加。

## 変更内容
- MapPreview
  - 保存済みピンをクリックすると PlaceDetailCard を表示する処理を追加
  - place_status API からサムネイルURLを取得してカードに表示
  - 詳細カード表示時にシートを最大サイズに展開
- PlaceDetailCard
  - 保存状態に応じてUIを切り替え（追加済み表示・削除ボタン表示など）
  - サムネイル表示に対応
- MobileLayout
  - MapPreviewの`onRequestExpand`を利用し、カード表示時にシートを展開

## 動作確認
- 保存済みのピンをクリックすると詳細カードが表示される
- カードには場所名・サムネイル・追加済み表示が出る
- 未保存のピンをクリックした場合は従来通りポップアップが表示される
