### PR TITLE
feat(api): add users table

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,8 +1,6 @@
 FROM ruby:3.4.5
 
 RUN apt-get update && apt-get install -y \
-    nodejs \
-    yarn \
     default-mysql-client \
     && rm -rf /var/lib/apt/lists/*
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,0 +1,2 @@
+class User < ApplicationRecord
+end

--- a/api/db/migrate/20250813142300_create_users.rb
+++ b/api/db/migrate/20250813142300_create_users.rb
@@ -1,0 +1,7 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.timestamps null: false
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_10_092028) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_13_142300) do
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "address", null: false
@@ -20,6 +20,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_10_092028) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["place_id"], name: "index_places_on_place_id", unique: true
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "video_view_places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
## 概要
usersテーブルの作成

## 変更内容
- usersテーブルを追加(id, created_at, updated_at)

## 動作確認
- `docker compose exec api bin/rails db:migrate`が成功することを確認
- `rails c`で`User.create!`が成功することを確認