### PR TITLE
feat(api): implement visitor-token based guest identification

### DIFF
--- a/api/app/controllers/api/identities_controller.rb
+++ b/api/app/controllers/api/identities_controller.rb
@@ -1,0 +1,8 @@
+class Api::IdentitiesController < ApplicationController
+  def show
+    render json: {
+      user_id: current_user.id,
+      token: visitor_token || request.headers['X-Visitor-Token']
+    }
+  end
+end

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
   include ActionController::RequestForgeryProtection
   protect_from_forgery with: :null_session
+  include IdentifiesUser
 end

--- a/api/app/controllers/concerns/identifies_user.rb
+++ b/api/app/controllers/concerns/identifies_user.rb
@@ -1,0 +1,39 @@
+module IdentifiesUser
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :identify_user
+    attr_reader :current_user, :visitor_token
+  end
+
+  private
+
+  def identify_user
+    token = request.headers['X-Visitor-Token'].presence
+    @visitor_token = token
+
+    if token
+      uv = UserVisit.includes(:user).find_by(token: token)
+      if uv
+        @current_user = uv.user
+      else
+        create_user_and_visit!(token)
+      end
+    else
+      token = SecureRandom.uuid
+      create_user_and_visit!(token)
+      @visitor_token = token
+    end
+
+    response.set_header('X-Visitor-Token', @visitor_token)
+  end
+
+  def create_user_and_visit!(token)
+    @current_user = User.create!
+    begin
+      UserVisit.create!(user: @current_user, token: token, created_at: Time.current)
+    rescue ActiveRecord::RecordNotUnique
+      @current_user = UserVisit.find_by!(token: token).user
+    end
+  end
+end

--- a/api/app/models/user_visit.rb
+++ b/api/app/models/user_visit.rb
@@ -1,0 +1,4 @@
+class UserVisit < ApplicationRecord
+  belongs_to :user
+  validates :token, presence: true, uniqueness: true, length: { maximum: 36 }
+end

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -7,7 +7,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
     resource '*',
       headers: :any,
       methods: [:get, :post, :put, :patch, :delete, :options],
-      expose: [],
+      expose: %w[X-Visitor-Token],
       credentials: false,
       max_age: 600
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
         get :place_status
       end
     end
+    resource :identity, only: [:show]
   end
 end

--- a/api/db/migrate/20250813143627_create_user_visits.rb
+++ b/api/db/migrate/20250813143627_create_user_visits.rb
@@ -1,0 +1,11 @@
+class CreateUserVisits < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_visits do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.string :token, null: false, limit: 36
+      t.datetime :created_at, null: false
+    end
+
+    add_index :user_visits, :token, unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_13_142300) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_13_143627) do
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "address", null: false
@@ -20,6 +20,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_142300) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["place_id"], name: "index_places_on_place_id", unique: true
+  end
+
+  create_table "user_visits", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", limit: 36, null: false
+    t.datetime "created_at", null: false
+    t.index ["token"], name: "index_user_visits_on_token", unique: true
+    t.index ["user_id"], name: "index_user_visits_on_user_id", unique: true
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -47,6 +55,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_142300) do
     t.index ["youtube_video_id"], name: "index_video_views_on_youtube_video_id", unique: true
   end
 
+  add_foreign_key "user_visits", "users"
   add_foreign_key "video_view_places", "places"
   add_foreign_key "video_view_places", "video_views"
 end


### PR DESCRIPTION
## 概要
ゲストユーザーを visitor-token で識別し、自動的に User レコードを割り当てる仕組みを実装。
初回アクセス時にトークンを発行・保存し、以降のリクエストでは同一ユーザーとして処理するように変更。

## 変更内容
- user_visits テーブルの追加
  - user_id（ユニーク制約あり）
  - token（36文字以内、ユニーク制約あり）
  - created_at
- モデル UserVisit を作成
  - belongs_to :user
  - token の必須・一意・長さ制限バリデーションを追加
- IdentifiesUser concern の追加
  - リクエストヘッダー X-Visitor-Token をチェック
  - 該当トークンが存在すれば既存ユーザーを取得、なければ作成
  - レスポンスヘッダーに X-Visitor-Token を返却
- ApplicationController に concern を include
- GET /api/identity エンドポイントを追加（動作確認用、将来的に削除予定）
- CORS 設定を更新
  - X-Visitor-Token ヘッダーの許可と expose を追加
 
## 動作確認
1. マイグレーション実行
   `docker compose exec api bin/rails db:migrate`

2. 初回アクセス（トークンなし）
   `curl -i http://localhost:3000/api/identity`
   → レスポンスヘッダーに X-Visitor-Token が付与されることを確認

3. 再アクセス（トークンあり）
   `curl -i http://localhost:3000/api/identity -H "X-Visitor-Token: <前回のトークン>"`
   → 同じ user_id が返ることを確認