### PR TITLE
feat(front): implement visitor-token client and TopPage start flow

### DIFF
--- a/api/app/controllers/api/identities_controller.rb
+++ b/api/app/controllers/api/identities_controller.rb
@@ -1,5 +1,6 @@
 class Api::IdentitiesController < ApplicationController
   def show
+    response.set_header('X-Visitor-Token', visitor_token)
     render json: {
       user_id: current_user.id,
       token: visitor_token || request.headers['X-Visitor-Token']

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import "./App.css";
 import Header from "./components/Header";
 import ScrollToTop from "./components/ScrollToTop";
+import TopPage from "./pages/TopPage";
 import Homepage from "./pages/HomePage";
 import SearchResultPage from "./pages/SearchResultPage";
 import VideoDetailPage from "./pages/VideoDetailPage";
@@ -12,7 +13,8 @@ const App = () => {
       <Header />
       <ScrollToTop />
       <Routes>
-        <Route path="/" element={<Homepage />} />
+        <Route path="/" element={<TopPage />} />
+        <Route path="/home" element={<Homepage />} />
         <Route path="/search" element={<SearchResultPage />} />
         <Route path="/video/:id" element={<VideoDetailPage />} />
       </Routes>

--- a/front/src/api/bookmarks.js
+++ b/front/src/api/bookmarks.js
@@ -1,7 +1,8 @@
+import { apiFetch } from "./client";
 const base = import.meta.env.VITE_API_BASE_URL || '';
 
 export async function createBookmark(payload) {
-  const res = await fetch(`${base}/api/bookmarks`, {
+  const res = await apiFetch(`${base}/api/bookmarks`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
@@ -14,13 +15,13 @@ export async function existsBookmark({ youtube_video_id, place_id }) {
   const url = new URL(`${base}/api/bookmarks/exists`);
   url.searchParams.set('youtube_video_id', youtube_video_id);
   url.searchParams.set('place_id', place_id);
-  const res = await fetch(url);
+  const res = await apiFetch(url.toString());
   if (!res.ok) throw new Error(`exists failed: ${res.status}`);
   return res.json();
 }
 
 export async function totalCountBookmarks() {
-  const res = await fetch(`${base}/api/bookmarks/total_count`);
+  const res = await apiFetch(`${base}/api/bookmarks/total_count`);
   if (!res.ok) throw new Error("totalCountBookmarks failed");
   return res.json();
 }
@@ -28,7 +29,7 @@ export async function totalCountBookmarks() {
 export async function placeStatus({ place_id }) {
   const url = new URL(`${base}/api/bookmarks/place_status`);
   url.searchParams.set('place_id', place_id);
-  const res = await fetch(url);
+  const res = await apiFetch(url.toString());
   if (!res.ok) throw new Error(`placeStatus failed: ${res.status}`);
   return res.json();
 }

--- a/front/src/api/client.js
+++ b/front/src/api/client.js
@@ -1,0 +1,21 @@
+const TOKEN_KEY = "visitor_token";
+
+function getVisitorToken() {
+  return localStorage.getItem(TOKEN_KEY);
+}
+function setVisitorToken(t) {
+  if (t) localStorage.setItem(TOKEN_KEY, t);
+}
+
+export async function apiFetch(url, options={}) {
+  const headers = new Headers(options.headers || {});
+  const token = getVisitorToken();
+  if (token) headers.set("X-Visitor-Token", token);
+
+  const res = await fetch(url, { ...options, headers });
+
+  const newToken = res.headers.get("X-Visitor-Token");
+  if (newToken && newToken !== token) setVisitorToken(newToken);
+
+  return res;
+}

--- a/front/src/api/client.js
+++ b/front/src/api/client.js
@@ -1,13 +1,14 @@
-const TOKEN_KEY = "visitor_token";
+export const TOKEN_KEY = "visitor_token";
 
-function getVisitorToken() {
+export function getVisitorToken() {
   return localStorage.getItem(TOKEN_KEY);
 }
 function setVisitorToken(t) {
   if (t) localStorage.setItem(TOKEN_KEY, t);
 }
+export const __setVisitorToken = setVisitorToken;
 
-export async function apiFetch(url, options={}) {
+export async function apiFetch(url, options = {}) {
   const headers = new Headers(options.headers || {});
   const token = getVisitorToken();
   if (token) headers.set("X-Visitor-Token", token);

--- a/front/src/api/identity.js
+++ b/front/src/api/identity.js
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client";
+import { apiFetch, __setVisitorToken } from "./client";
 const base = import.meta.env.VITE_API_BASE_URL || "";
 
 export async function fetchIdentity() {
@@ -10,5 +10,7 @@ export async function fetchIdentity() {
 export async function ensureVisitor() {
   const existing = localStorage.getItem("visitor_token");
   if (existing) return { token: existing };
-  return fetchIdentity();
+  const data = await fetchIdentity();
+  if (data?.token) __setVisitorToken(data.token);
+  return data;
 }

--- a/front/src/api/identity.js
+++ b/front/src/api/identity.js
@@ -1,0 +1,14 @@
+import { apiFetch } from "./client";
+const base = import.meta.env.VITE_API_BASE_URL || "";
+
+export async function fetchIdentity() {
+  const res = await apiFetch(`${base}/api/identity`);
+  if (!res.ok) throw new Error("identity failed");
+  return res.json();
+}
+
+export async function ensureVisitor() {
+  const existing = localStorage.getItem("visitor_token");
+  if (existing) return { token: existing };
+  return fetchIdentity();
+}

--- a/front/src/pages/TopPage.jsx
+++ b/front/src/pages/TopPage.jsx
@@ -1,6 +1,68 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ensureVisitor } from "../api/identity";
+
 const TopPage = () => {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+
+  const handleStart = async () => {
+      try {
+          setLoading(true);
+          await ensureVisitor();
+          navigate("/home", { replace: true });
+      } catch (e) {
+          console.error(e);
+          alert("初期化に失敗しました。ネットワークを確認してください。");
+      } finally {
+          setLoading(false);
+      }
+  };
+
   return (
-    <h1>TOPページ</h1>
+    <main style={{ maxWidth: 420, margin: "0 auto", padding: 16 }}>
+      <h1 style={{ textAlign: "center" }}>VloMaPlan</h1>
+      <p style={{ textAlign: "center" }}>
+        動画から旅のヒントを得よう<br/>〜Vlog視聴・Map検索・プラン作成 すべてこれ一つで〜
+      </p>
+
+      <button
+        onClick={handleStart}
+        disabled={loading}
+        style={{
+        width: "100%", padding: "12px 16px", borderRadius: 9999,
+        border: "none", background: "#2CA478", color: "#fff", fontWeight: 700
+        }}
+      >
+        {loading ? "はじめています…" : "さっそく使ってみる"}
+      </button>
+
+      <button
+        style={{
+        width: "100%", padding: "12px 16px", borderRadius: 9999,
+        marginTop: 12, background: "transparent", color: "#2CA478",
+        border: "2px solid #2CA478", fontWeight: 700
+        }}
+        onClick={() => alert("（将来）ユーザー登録へ")}
+      >
+        ユーザー登録
+      </button>
+
+      <button
+        style={{
+        width: "100%", padding: "12px 16px", borderRadius: 9999,
+        marginTop: 12, background: "#2CA478", color: "#fff", fontWeight: 700
+        }}
+        onClick={() => alert("（将来）ログインへ")}
+      >
+        ログイン
+      </button>
+
+      <div style={{ marginTop: 24, height: 200, background: "#e5e5e5",
+                    borderRadius: 8, display: "grid", placeItems: "center" }}>
+          使い方
+      </div>
+    </main>
   )
 }
 

--- a/front/src/pages/TopPage.jsx
+++ b/front/src/pages/TopPage.jsx
@@ -1,0 +1,7 @@
+const TopPage = () => {
+  return (
+    <h1>TOPページ</h1>
+  )
+}
+
+export default TopPage;


### PR DESCRIPTION
## 概要
フロントエンド側に visitor-token を利用したゲストユーザー識別の仕組みを実装。
初回アクセス時に /api/identity を呼び、取得したトークンを localStorage に保存。
以降の全APIリクエストに自動で付与。
また、TopPageとHomePageを分離し、TopPageから利用開始するように変更。

## 変更内容
- ルーティングを "/" (TopPage) と "/home" に分離
- 共通fetchラッパー `apiFetch` を作成
  - X-Visitor-Token の付与と保存を自動化
- /api/identity を呼び出す `fetchIdentity` / `ensureVisitor` 関数を追加
  - 初回アクセス時にゲストユーザーを自動生成
- TopPageから「さっそく使ってみる」ボタンで /home に遷移するように変更
- 既存のAPI呼び出しを `apiFetch` 経由に置き換え

## 動作確認
1. "/" にアクセスし、TopPageが表示されること
2. 「さっそく使ってみる」クリック時に /api/identity が呼ばれ、X-Visitor-Token が localStorage に保存されること
3. /home に遷移後、既存API呼び出し時に X-Visitor-Token が自動で送信されること
4. 再読み込み後も localStorage のトークンが利用され、同一ユーザーとして扱われること