### PR TITLE
feat(front): add dedicated TopPage header and layout

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -1,7 +1,7 @@
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import "./App.css";
-import Header from "./components/Header";
-import ScrollToTop from "./components/ScrollToTop";
+import TopLayout from "./components/layouts/TopLayout";
+import MainLayout from "./components/layouts/MainLayout";
 import TopPage from "./pages/TopPage";
 import Homepage from "./pages/HomePage";
 import SearchResultPage from "./pages/SearchResultPage";
@@ -10,13 +10,15 @@ import VideoDetailPage from "./pages/VideoDetailPage";
 const App = () => {
   return (
     <Router>
-      <Header />
-      <ScrollToTop />
       <Routes>
-        <Route path="/" element={<TopPage />} />
-        <Route path="/home" element={<Homepage />} />
-        <Route path="/search" element={<SearchResultPage />} />
-        <Route path="/video/:id" element={<VideoDetailPage />} />
+        <Route element={<TopLayout />}>
+          <Route path="/" element={<TopPage />} />
+          <Route path="/home" element={<Homepage />} />
+        </Route>
+        <Route element={<MainLayout />}>
+          <Route path="/search" element={<SearchResultPage />} />
+          <Route path="/video/:id" element={<VideoDetailPage />} />
+        </Route>
       </Routes>
     </Router>
   );

--- a/front/src/components/TopHeader.jsx
+++ b/front/src/components/TopHeader.jsx
@@ -1,0 +1,16 @@
+const TopHeader = () => {
+  return (
+    <header
+      style={{
+        backgroundColor: "#eee",
+        padding: "10px",
+        display: "flex",
+        justifyContent: "space-between"
+      }}>
+      <h1>VloMaPlan</h1>
+      <h1>Menu</h1>
+    </header>
+  )
+}
+
+export default TopHeader;

--- a/front/src/components/layouts/MainLayout.jsx
+++ b/front/src/components/layouts/MainLayout.jsx
@@ -1,0 +1,15 @@
+import ScrollToTop from "../ScrollToTop";
+import Header from "../Header";
+import { Outlet } from "react-router-dom";
+
+const MainLayout = () => {
+  return (
+      <>
+        <Header />
+        <ScrollToTop />
+        <Outlet />
+      </>
+  );
+};
+
+export default MainLayout;

--- a/front/src/components/layouts/TopLayout.jsx
+++ b/front/src/components/layouts/TopLayout.jsx
@@ -1,0 +1,15 @@
+import TopHeader from "../TopHeader";
+import ScrollToTop from "../ScrollToTop";
+import { Outlet } from "react-router-dom";
+
+const TopLayout = () => {
+  return (
+      <>
+        <TopHeader></TopHeader>
+        <ScrollToTop />
+        <Outlet />
+      </>
+  );
+};
+
+export default TopLayout;

--- a/front/src/pages/TopPage.jsx
+++ b/front/src/pages/TopPage.jsx
@@ -10,7 +10,7 @@ const TopPage = () => {
       try {
           setLoading(true);
           await ensureVisitor();
-          navigate("/home", { replace: true });
+          navigate("/home");
       } catch (e) {
           console.error(e);
           alert("初期化に失敗しました。ネットワークを確認してください。");


### PR DESCRIPTION
## 概要
TOPページ専用のヘッダーとレイアウトを追加し、ルーティングを調整。
TOPページ（"/"）では新規作成した TopHeader を表示し、
その他のページでは従来の Header を使用する構成に変更。

## 変更内容
- 新規コンポーネント
  - TopHeader: TOP・HOMEページ専用の簡易ヘッダー
  - TopLayout: TopHeader + ScrollToTop + Outlet
  - MainLayout: Header + ScrollToTop + Outlet
- App.jsx のルーティングを更新

# 動作確認
1. "/" にアクセスすると TopHeader が表示され、メインのコンテンツが TopPage として表示されること
2. "/home" にアクセスするとTopHeaderが表示されること
3. "/search" などでは従来の Header が表示されること
4. ルーティングが正しく動作し、ページ遷移時に ScrollToTop が有効であること