### PR TITLE
Feature/api add wishlists and update bookmarks create

### DIFF
--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -20,11 +20,15 @@ class Api::BookmarksController < ApplicationController
 
       VideoViewPlace.create_or_find_by!(video_view: vv, place: place)
 
+      Wishlist.create_or_find_by!(user: current_user, place: place) do |w|
+        w.created_at = Time.current
+      end
+
       render json: {
         video_view: { id: vv.id, youtube_video_id: vv.youtube_video_id },
         place: { id: place.id, place_id: place.place_id, name: place.name },
-        linked: true
-      }, status: :created
+        wishlist: { saved: true }
+      }
     end
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity

--- a/api/app/models/wishlist.rb
+++ b/api/app/models/wishlist.rb
@@ -1,0 +1,5 @@
+class Wishlist < ApplicationRecord
+  belongs_to :user
+  belongs_to :place
+  validates :user_id, uniqueness: { scope: :place_id }
+end

--- a/api/db/migrate/20250814125246_create_wishlists.rb
+++ b/api/db/migrate/20250814125246_create_wishlists.rb
@@ -1,0 +1,11 @@
+class CreateWishlists < ActiveRecord::Migration[8.0]
+  def change
+    create_table :wishlists do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :place, null: false, foreign_key: true
+      t.datetime :created_at, null: false
+    end
+
+    add_index :wishlists, [:user_id, :place_id], unique: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_13_143627) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_14_125246) do
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "address", null: false
@@ -55,7 +55,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_13_143627) do
     t.index ["youtube_video_id"], name: "index_video_views_on_youtube_video_id", unique: true
   end
 
+  create_table "wishlists", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "place_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["place_id"], name: "index_wishlists_on_place_id"
+    t.index ["user_id", "place_id"], name: "index_wishlists_on_user_id_and_place_id", unique: true
+    t.index ["user_id"], name: "index_wishlists_on_user_id"
+  end
+
   add_foreign_key "user_visits", "users"
   add_foreign_key "video_view_places", "places"
   add_foreign_key "video_view_places", "video_views"
+  add_foreign_key "wishlists", "places"
+  add_foreign_key "wishlists", "users"
 end


### PR DESCRIPTION
## 概要
ユーザーがお気に入り（Wishlist）として場所を保存できるようにするため、
Wishlistsテーブルを新規作成し、bookmarks#createにWishlist登録処理を追加。

# 変更内容
- wishlistsテーブルを新規作成
  - user_id（外部キー制約あり）
  - place_id（外部キー制約あり）
  - created_at
  - user_id と place_id の複合ユニークインデックス
- Wishlistモデルを追加
  - belongs_to :user
  - belongs_to :place
  - user_id + place_id の組み合わせの一意性バリデーション
- bookmarks#create を更新
  - VideoView と Place の紐付けに加え、Wishlistにも登録
  - Wishlist作成時にはcreated_atを現在時刻で設定
  - レスポンスにwishlistの保存状態を追加

# 動作確認
1. マイグレーションを実行
   docker compose exec api bin/rails db:migrate

2. 新しい場所をbookmarks#createで登録すると、
   wishlistsテーブルに user_id + place_id のレコードが作成されることを確認

3. create APIレスポンスに { wishlist: { saved: true } } が含まれることを確認
