### PR TITLE
feat(api,front): switch favorite count to wishlists, remove bookmarks#exists

### DIFF
--- a/api/app/controllers/api/bookmarks_controller.rb
+++ b/api/app/controllers/api/bookmarks_controller.rb
@@ -27,26 +27,11 @@ class Api::BookmarksController < ApplicationController
       render json: {
         video_view: { id: vv.id, youtube_video_id: vv.youtube_video_id },
         place: { id: place.id, place_id: place.place_id, name: place.name },
-        wishlist: { saved: true }
+        wishlist: { saved: true }  
       }
     end
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: e.record.errors.full_messages }, status: :unprocessable_entity
-  end
-
-  def exists
-    youtube_id = params.require(:youtube_video_id)
-    place_id = params.require(:place_id)
-
-    vv = VideoView.find_by(youtube_video_id: youtube_id)
-    place = Place.find_by(place_id: place_id)
-    present = vv && place && VideoViewPlace.exists?(video_view_id: vv.id, place_id: place.id)
-    render json: { exists: !!present }
-  end
-
-  def total_count
-    total = VideoViewPlace.count
-    render json: { total_count: total }
   end
 
   def place_status

--- a/api/app/controllers/api/wishlists_controller.rb
+++ b/api/app/controllers/api/wishlists_controller.rb
@@ -1,0 +1,6 @@
+class Api::WishlistsController < ApplicationController
+  def total_count
+    cnt = Wishlist.where(user: current_user).count
+    render json: { total_count: cnt }
+  end
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -2,11 +2,14 @@ Rails.application.routes.draw do
   namespace :api do
     resources :bookmarks, only: [:create] do
       collection do
-        get :exists
-        get :total_count
         get :place_status
       end
     end
     resource :identity, only: [:show]
+    resources :wishlists, only: [] do
+      collection do
+        get :total_count
+      end
+    end
   end
 end

--- a/front/src/api/bookmarks.js
+++ b/front/src/api/bookmarks.js
@@ -11,15 +11,6 @@ export async function createBookmark(payload) {
   return res.json();
 }
 
-export async function existsBookmark({ youtube_video_id, place_id }) {
-  const url = new URL(`${base}/api/bookmarks/exists`);
-  url.searchParams.set('youtube_video_id', youtube_video_id);
-  url.searchParams.set('place_id', place_id);
-  const res = await apiFetch(url.toString());
-  if (!res.ok) throw new Error(`exists failed: ${res.status}`);
-  return res.json();
-}
-
 export async function totalCountBookmarks() {
   const res = await apiFetch(`${base}/api/bookmarks/total_count`);
   if (!res.ok) throw new Error("totalCountBookmarks failed");

--- a/front/src/api/wishlists.js
+++ b/front/src/api/wishlists.js
@@ -1,0 +1,8 @@
+import { apiFetch } from "./client";
+const base = import.meta.env.VITE_API_BASE_URL || "";
+
+export async function totalCountWishlists() {
+  const res = await apiFetch(`${base}/api/wishlists/total_count`);
+  if (!res.ok) throw new Error("totalCountWishlists failed");
+  return res.json();
+}

--- a/front/src/components/MapPreview.jsx
+++ b/front/src/components/MapPreview.jsx
@@ -3,7 +3,8 @@ import { useMap, Map } from "@vis.gl/react-google-maps";
 import CustomMarker from "./CustomMarker";
 import MapPopup from "./MapPopup";
 import PlaceDetailCard from "./PlaceDetailCard";
-import { createBookmark, placeStatus, totalCountBookmarks } from "../api/bookmarks";
+import { createBookmark, placeStatus } from "../api/bookmarks";
+import { totalCountWishlists } from "../api/wishlists";
 
 const MapPreview = ({
   position,
@@ -56,7 +57,7 @@ const MapPreview = ({
   useEffect(() => {
     (async () => {
       try {
-        const { total_count } = await totalCountBookmarks();
+        const { total_count } = await totalCountWishlists();
         setTotalFavCount(Number(total_count || 0));
       } catch (e) {
         console.warn("total_count init failed:", e);
@@ -103,7 +104,10 @@ const MapPreview = ({
         },
       });
       setIsSavedGlobally(true);
-      setTotalFavCount((c) => c + 1);
+      try {
+        const { total_count } = await totalCountWishlists();
+        setTotalFavCount(Number(total_count || 0));
+      } catch {}
       setIsPopupOpen(false);
       setShowDetail(true);
       onRequestExpand?.();


### PR DESCRIPTION
## 概要
「いきたい場所（Wishlist）」の総数をユーザー単位で取得できるようにし、
フロントのバッジ表示を wishlists 基準に切り替え。
不要になった`bookmarks#exists` を廃止し、ルーティング＆呼び出しを整理。

## 変更内容
### API
- ルーティング更新
  - `resources :wishlists` に `GET /api/wishlists/total_count` を追加
  - `bookmarks#exists` を削除（/api/bookmarks/exists 廃止）
- コントローラ
  - `Api::WishlistsController#total_count` を追加
    - ログイン（visitor-token）中の `current_user` に紐づく wishlist 件数を返却
  - `Api::BookmarksController`
    - `create`：保存時に Wishlist を `create_or_find_by!` で作成（既存のまま）
    - `place_status`：表示用の最新サムネ取得ロジックを維持
    - （必要に応じて）`total_count` の実装を見直し

### Front
- `front/src/api/wishlists.js`
  - `totalCountWishlists()` を追加（`/api/wishlists/total_count`）
- `front/src/api/bookmarks.js`
  - `exists` 呼び出しを削除
  - `total_count`・`place_status` は既存通り
- `front/src/components/MapPreview.jsx`
  - 起動時に `totalCountWishlists()` を呼び、ヘッダー右上のハートバッジに総数を表示
  - 保存後も再取得してバッジを更新
  - 既存の `place_status` による個別保存状態表示は維持
  
  # 動作確認
1. API
   - `GET /api/wishlists/total_count` が 200 で { total_count: <数値> } を返す
   - `bookmarks#exists` がルーティングから消えている（404/未定義）

2. Front（MapPreview）
   - 初期表示でハートバッジに wishlist 合計が表示される（0 の時は非表示）
   - 「追加する」実行後、wishlist 合計が +1 されて再表示される
   - 既存の「保存済みかどうか（place_status）」の挙動は従来通り

3. 既存機能が壊れていないかを確認
   - `/api/bookmarks` への POST が成功し、Wishlist が作成される
   - 既存のサムネ表示や詳細カードの表示が崩れていない