### PR TITLE
Feature/wishlists status endpoints

### DIFF
--- a/api/app/controllers/api/wishlists_controller.rb
+++ b/api/app/controllers/api/wishlists_controller.rb
@@ -1,4 +1,19 @@
 class Api::WishlistsController < ApplicationController
+  def status
+    pid = params.require(:place_id)
+    place = Place.find_by(place_id: pid)
+
+    saved = place.present? && Wishlist.exists?(user: current_user, place: place)
+
+    thumb = nil
+    if place
+      vvp = place.video_view_places.includes(:video_view).order(created_at: :desc).first
+      thumb = vvp&.video_view&.thumbnail_url
+    end
+
+    render json: { saved: saved, thumbnail_url: thumb }
+  end
+
   def total_count
     cnt = Wishlist.where(user: current_user).count
     render json: { total_count: cnt }

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,14 +1,11 @@
 Rails.application.routes.draw do
   namespace :api do
-    resources :bookmarks, only: [:create] do
-      collection do
-        get :place_status
-      end
-    end
+    resources :bookmarks, only: [:create]
     resource :identity, only: [:show]
     resources :wishlists, only: [] do
       collection do
         get :total_count
+        get :status
       end
     end
   end

--- a/front/src/api/wishlists.js
+++ b/front/src/api/wishlists.js
@@ -1,6 +1,14 @@
 import { apiFetch } from "./client";
 const base = import.meta.env.VITE_API_BASE_URL || "";
 
+export async function wishlistsStatus({ place_id }) {
+  const url = new URL(`${base}/api/wishlists/status`);
+  url.searchParams.set("place_id", place_id);
+  const res = await apiFetch(url.toString());
+  if (!res.ok) throw new Error(`wishlistStatus failed: ${res.status}`);
+  return res.json();
+}
+
 export async function totalCountWishlists() {
   const res = await apiFetch(`${base}/api/wishlists/total_count`);
   if (!res.ok) throw new Error("totalCountWishlists failed");

--- a/front/src/components/MapPreview.jsx
+++ b/front/src/components/MapPreview.jsx
@@ -3,8 +3,8 @@ import { useMap, Map } from "@vis.gl/react-google-maps";
 import CustomMarker from "./CustomMarker";
 import MapPopup from "./MapPopup";
 import PlaceDetailCard from "./PlaceDetailCard";
-import { createBookmark, placeStatus } from "../api/bookmarks";
-import { totalCountWishlists } from "../api/wishlists";
+import { createBookmark } from "../api/bookmarks";
+import { totalCountWishlists, wishlistsStatus } from "../api/wishlists";
 
 const MapPreview = ({
   position,
@@ -29,19 +29,6 @@ const MapPreview = ({
   const prevH = useRef(mapHeight);
 
   const [placeThumbUrl, setPlaceThumbUrl] = useState(null);
-
-  useEffect(() => {
-    if (!selectedPlace?.place_id) return;
-    (async () => {
-      try {
-        const res = await placeStatus({ place_id: selectedPlace.place_id });
-        setPlaceThumbUrl(res.thumbnail_url || null);
-      } catch (e) {
-        console.error("place_status failed", e);
-        setPlaceThumbUrl(null);
-      }
-    })();
-  }, [selectedPlace?.place_id]);
 
   useEffect(() => {
     if (!map) return;
@@ -70,11 +57,13 @@ const MapPreview = ({
     if (!pid) return;
     (async () => {
       try {
-        const { saved } = await placeStatus({ place_id: pid });
+        const { saved, thumbnail_url } = await wishlistsStatus({ place_id: pid });
         setIsSavedGlobally(!!saved);
+        setPlaceThumbUrl(thumbnail_url || null);
       } catch (e) {
         console.warn("place_status init failed:", e);
         setIsSavedGlobally(false);
+        setPlaceThumbUrl(null);
       }
     })();
   }, [selectedPlace?.place_id]);


### PR DESCRIPTION
## 概要
bookmarks#place_status を wishlists コントローラに移行し、行きたい場所リストに関連する API として整理。

## 変更内容
- routes.rb にて wishlists に `status` / `total_count` エンドポイントを追加
- WishlistsControllerに、`status` と `total_count` を返却する処理を作成
- フロントエンドの API 呼び出しを `wishlists.js` に移行
- MapPreview コンポーネントを修正し、新しい wishlists API を利用するよう変更

## 動作確認
- 選択した場所が「行きたい場所リスト」に保存されているかどうかを正しく判定できることを確認
- リストの総数が正しく取得・表示されることを確認
- 既存のブックマーク追加処理との互換性も維持されていることを確認
