### PR TITLE
feat(api): add wishlist index endpoint with pagy pagination

### DIFF
--- a/api/Gemfile
+++ b/api/Gemfile
@@ -49,3 +49,4 @@ group :development do
 end
 
 gem "rack-cors", "~> 3.0"
+gem "pagy"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.18.9-x86_64-linux-musl)
       racc (~> 1.4)
+    pagy (9.4.0)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -268,6 +269,7 @@ DEPENDENCIES
   brakeman
   debug
   mysql2 (~> 0.5)
+  pagy
   puma (>= 5.0)
   rack-cors (~> 3.0)
   rails (~> 8.0.2)

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@ class ApplicationController < ActionController::API
   include ActionController::RequestForgeryProtection
   protect_from_forgery with: :null_session
   include IdentifiesUser
+  include Pagy::Backend
 end

--- a/api/config/initializers/pagy.rb
+++ b/api/config/initializers/pagy.rb
@@ -1,0 +1,10 @@
+require "pagy/extras/countless"
+require "pagy/extras/limit"
+require "pagy/extras/metadata"
+require "pagy/extras/overflow"
+
+Pagy::DEFAULT[:limit] = 20
+Pagy::DEFAULT[:limit_max] = 100
+Pagy::DEFAULT[:limit_param] = :per
+Pagy::DEFAULT[:metadata] = [:page, :limit, :prev, :next]
+Pagy::DEFAULT[:overflow] = :empty_page

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :bookmarks, only: [:create]
     resource :identity, only: [:show]
-    resources :wishlists, only: [] do
+    resources :wishlists, only: [:index] do
       collection do
         get :total_count
         get :status


### PR DESCRIPTION
## 概要
行きたい場所リストをフロントエンドで一覧表示できるようにするための API 下準備を追加。

## 変更内容
- `Gemfile` に `pagy` を追加し、ページネーションを利用可能に
- `config/initializers/pagy.rb` に初期設定を追加
- `ApplicationController` に `Pagy::Backend` を include
- `routes.rb` に `wishlists#index` エンドポイントを追加
- `Api::WishlistsController`
  - `index`: ページネーション付きでユーザーの行きたい場所リストを返却する処理を実装
  - `status` / `total_count` はそのまま利用
- 取得データにはサムネイルや Place 情報を含めるように整形

## 動作確認
以下のコマンドで期待通りのレスポンスが返却されることを確認。
```bash
TOKEN='コピーしたvisitor_token'
curl -s "http://localhost:3000/api/wishlists?per=20" \
  -H "X-Visitor-Token: $TOKEN" | jq
