### PR TITLE
feat(api,front): add wishlist deletion; make bookmark creation idempotent

### DIFF
--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :bookmarks, only: [:create]
     resource :identity, only: [:show]
-    resources :wishlists, only: [:index] do
+    resources :wishlists, only: [:index, :destroy] do
       collection do
         get :total_count
         get :status

--- a/front/src/api/wishlists.js
+++ b/front/src/api/wishlists.js
@@ -23,3 +23,10 @@ export async function listWishlists({ page = 1, per = 20 } = {}) {
   if (!res.ok) throw new Error(`listWishlists failed: ${res.status}`);
   return res.json();
 }
+
+export async function deleteWishlist(id) {
+  const res = await apiFetch(`${base}/api/wishlists/${id}`, { method: "DELETE" });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`deleteWishlist failed: ${res.status}`);
+  }
+}


### PR DESCRIPTION
## 概要
- Wishlist からの**削除機能**を追加、削除後に同じ場所を**再追加**できるように変更。
- `status` / `create` のレスポンスに `wishlist_id` を返すようにして、フロントからの削除・再追加フローを修正。

## 変更内容
- **Rails / API**
  - ルーティングに `DELETE /api/wishlists/:id` を追加。
  - `Api::WishlistsController#status` が `wishlist_id` を返却。
  - `Api::BookmarksController#create` を `find_or_create_by!` ベースに変更（`VideoView` / `Place` / `VideoViewPlace` / `Wishlist` を冪等化）。
  - `POST /api/bookmarks` のレスポンスに `wishlist.id` を含めて返却。

- **Front**
  - `deleteWishlist(id)` を追加し、`MapPreview.handleRemoveWishlist` から呼び出し。
  - オーバーレイの `PlaceDetailCard` に `onRemove` を渡し、共通削除ハンドラを利用。
  - 追加成功後に `status` を取り直し、`currentWishlistId` を更新。


## 動作確認
1. **オーバーレイから削除**
   - `DELETE /api/wishlists/:id` が **204** を返すこと
   - オーバーレイが閉じ、ピンが通常化、バッジが1減り、リストから該当行が消えること
2. **再追加**
   - 同じピンをクリック → 「追加しますか？」ポップアップ → 追加
   - `POST /api/bookmarks` が **200** を返し、レスポンスに `wishlist.id` が含まれること
   - `status` 再取得で `wishlist_id` が再設定され、「追加済み」に戻ること（422にならない）
3. **リストから削除**
   - 各行の「削除」で行が即時消える（楽観更新）・バッジが1減ること
   - 同じ場所のオーバーレイを開いていた場合は未保存化されること
4. **API 単体**
   - `GET /api/wishlists/status?place_id=...`：保存時は `wishlist_id` を返し、削除後は `null`
   - `POST /api/bookmarks`：`wishlist.id` を含む JSON を返却
   - `DELETE /api/wishlists/:id`：204 を返却