### PR TITLE
Feature/auth with user credentials

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,10 @@
+.git
+log
+tmp
+node_modules
+spec
+test
+coverage
+docker-compose.yml
+Dockerfile
+.env

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,21 +1,40 @@
-FROM ruby:3.4.5
+# syntax=docker/dockerfile:1
+ARG RUBY_VERSION=3.4.5
 
+FROM ruby:${RUBY_VERSION} AS base
 RUN apt-get update && apt-get install -y \
+    build-essential \
+    default-libmysqlclient-dev \
     default-mysql-client \
-    && rm -rf /var/lib/apt/lists/*
-
+ && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 
-COPY Gemfile Gemfile.lock /app/
+# ---- 開発用（docker compose で使う） ----
+FROM base AS dev
+ENV RAILS_ENV=development
+COPY Gemfile Gemfile.lock ./
 RUN bundle install
+COPY . .
+# 既存 entrypoint.sh の「PID削除」をCMDに内包
+CMD ["bash","-lc","rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b 0.0.0.0"]
 
-COPY . /app
+# ---- 本番用の依存だけでビルド ----
+FROM base AS prod-build
+ENV RAILS_ENV=production
+COPY Gemfile Gemfile.lock ./
+RUN bundle config set without 'development test' \
+ && bundle install --jobs=4 --retry=3
+COPY . .
 
-COPY entrypoint.sh /usr/bin/
-RUN sed -i 's/\r$//' /usr/bin/entrypoint.sh && chmod +x /usr/bin/entrypoint.sh
-
-ENTRYPOINT ["/usr/bin/entrypoint.sh"]
-
-EXPOSE 3000
-
-CMD ["rails", "server", "-b", "0.0.0.0"]
+# ---- 本番最終イメージ（軽量） ----
+  FROM ruby:${RUBY_VERSION}-slim AS app
+  # 開発ヘッダは不要。実行時ライブラリのみでOK
+  RUN apt-get update && apt-get install -y --no-install-recommends \
+      libmariadb3 \
+   && rm -rf /var/lib/apt/lists/*
+  ENV RAILS_ENV=production RACK_ENV=production
+  WORKDIR /app
+  COPY --from=prod-build /usr/local/bundle /usr/local/bundle
+  COPY --from=prod-build /app /app
+  EXPOSE 3000
+  CMD ["bash","-lc","bundle exec puma -C config/puma.rb"]

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -50,3 +50,4 @@ end
 
 gem "rack-cors", "~> 3.0"
 gem "pagy"
+gem "bcrypt", "~> 3.1"

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     bootsnap (1.18.6)
@@ -265,6 +266,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1)
   bootsnap
   brakeman
   debug

--- a/api/app/controllers/api/identities_controller.rb
+++ b/api/app/controllers/api/identities_controller.rb
@@ -1,6 +1,6 @@
 class Api::IdentitiesController < ApplicationController
   def show
-  ensure_visitor if params[:ensure].present? && current_user.nil?
+    ensure_visitor if params[:ensure].present? && current_user.nil?
 
     render json: {
       user_id: current_user.id,

--- a/api/app/controllers/api/identities_controller.rb
+++ b/api/app/controllers/api/identities_controller.rb
@@ -1,9 +1,10 @@
 class Api::IdentitiesController < ApplicationController
   def show
-    response.set_header('X-Visitor-Token', visitor_token)
+  ensure_visitor if params[:ensure].present? && current_user.nil?
+
     render json: {
       user_id: current_user.id,
-      token: visitor_token || request.headers['X-Visitor-Token']
+      token: visitor_token
     }
   end
 end

--- a/api/app/controllers/api/registrations_controller.rb
+++ b/api/app/controllers/api/registrations_controller.rb
@@ -1,11 +1,9 @@
 class Api::RegistrationsController < ApplicationController
   def create
     ApplicationRecord.transaction do
-    ensure_visitor if current_user.nil?
+      ensure_visitor if current_user.nil?
 
-      if current_user.user_credential.present?
-        render json: { error: "already_registered" }, status: :conflict and return
-      end
+      render json: { error: "already_registered" }, status: :conflict and return if current_user.user_credential.present?
 
       uc = current_user.build_user_credential(registration_params)
       uc.save!
@@ -26,6 +24,7 @@ class Api::RegistrationsController < ApplicationController
     return "email_unavailable" if record.errors.added?(:email, :taken)
     return "password_confirmation_mismatch" if record.errors.added?(:password_confirmation, :confirmation)
     return "weak_password" if record.errors.added?(:password, :too_short)
+
     "invalid_parameters"
   end
 end

--- a/api/app/controllers/api/registrations_controller.rb
+++ b/api/app/controllers/api/registrations_controller.rb
@@ -1,0 +1,31 @@
+class Api::RegistrationsController < ApplicationController
+  def create
+    ApplicationRecord.transaction do
+    ensure_visitor if current_user.nil?
+
+      if current_user.user_credential.present?
+        render json: { error: "already_registered" }, status: :conflict and return
+      end
+
+      uc = current_user.build_user_credential(registration_params)
+      uc.save!
+
+      render json: { ok: true, user_id: current_user.id, email: uc.email }, status: :created
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: map_registration_error(e.record) }, status: :unprocessable_entity
+  end
+
+  private
+
+  def registration_params
+    params.permit(:email, :password, :password_confirmation)
+  end
+
+  def map_registration_error(record)
+    return "email_unavailable" if record.errors.added?(:email, :taken)
+    return "password_confirmation_mismatch" if record.errors.added?(:password_confirmation, :confirmation)
+    return "weak_password" if record.errors.added?(:password, :too_short)
+    "invalid_parameters"
+  end
+end

--- a/api/app/controllers/api/sessions_controller.rb
+++ b/api/app/controllers/api/sessions_controller.rb
@@ -1,0 +1,31 @@
+class Api::SessionsController < ApplicationController
+  def create
+    email = params.require(:email).to_s.downcase
+    password = params.require(:password)
+
+    uc = UserCredential.find_by(email: email)
+    unless uc&.authenticate(password)
+      render json: { error: "invalid_credentials" }, status: :unauthorized and return
+    end
+
+    user = uc.user
+    token = SecureRandom.uuid
+
+    uv = UserVisit.find_or_initialize_by(user: user)
+    uv.token = token
+    uv.created_at ||= Time.current
+    uv.save!
+
+    response.set_header("X-Visitor-Token", token)
+    render json: { ok: true, user_id: user.id }
+  end
+
+  def destroy
+    if visitor_token.present?
+      if (uv = UserVisit.find_by(token: visitor_token))
+        uv.destroy
+      end
+    end
+    head :no_content
+  end
+end

--- a/api/app/controllers/api/sessions_controller.rb
+++ b/api/app/controllers/api/sessions_controller.rb
@@ -4,9 +4,7 @@ class Api::SessionsController < ApplicationController
     password = params.require(:password)
 
     uc = UserCredential.find_by(email: email)
-    unless uc&.authenticate(password)
-      render json: { error: "invalid_credentials" }, status: :unauthorized and return
-    end
+    render json: { error: "invalid_credentials" }, status: :unauthorized and return unless uc&.authenticate(password)
 
     user = uc.user
     token = SecureRandom.uuid
@@ -21,10 +19,8 @@ class Api::SessionsController < ApplicationController
   end
 
   def destroy
-    if visitor_token.present?
-      if (uv = UserVisit.find_by(token: visitor_token))
-        uv.destroy
-      end
+    if visitor_token.present? && (uv = UserVisit.find_by(token: visitor_token))
+      uv.destroy
     end
     head :no_content
   end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,2 +1,8 @@
 class User < ApplicationRecord
+  has_one :user_credential, dependent: :destroy
+  has_one :user_visit, dependent: :destroy
+
+  def registered?
+    user_credential.present?
+  end
 end

--- a/api/app/models/user_credential.rb
+++ b/api/app/models/user_credential.rb
@@ -1,0 +1,17 @@
+class UserCredential < ApplicationRecord
+  belongs_to :user
+
+  before_validation :normalize_email
+
+  validates :email, presence: true, length: { maximum: 255 }, uniqueness: { case_sensitive: false }
+
+  has_secure_password
+
+  validates :password, length: { minimum: 8 }, allow_nil: true
+
+  private
+
+  def normalize_email
+    self.email = email.to_s.strip.downcase
+  end
+end

--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
   config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/api/config/initializers/cors.rb
+++ b/api/config/initializers/cors.rb
@@ -2,7 +2,14 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:5173', 'http://127.0.0.1:5173'
+    dev_origins = %w[
+      http://localhost:5173
+      http://127.0.0.1:5173
+    ]
+    prod_origins = %w[
+      https://app.vlomaplan.com
+    ]
+    origins(*(Rails.env.development? ? dev_origins : prod_origins))
 
     resource '*',
              headers: :any,

--- a/api/config/puma.rb
+++ b/api/config/puma.rb
@@ -1,34 +1,11 @@
-# This configuration file will be evaluated by Puma. The top-level methods that
-# are invoked here are part of Puma's configuration DSL. For more information
-# about methods provided by the DSL, see https://puma.io/puma/Puma/DSL.html.
-
-# Puma starts a configurable number of processes (workers) and each process
-# serves each request in a thread from an internal thread pool.
-#
-# The ideal number of threads per worker depends both on how much time the
-# application spends waiting for IO operations and on how much you wish to
-# to prioritize throughput over latency.
-#
-# As a rule of thumb, increasing the number of threads will increase how much
-# traffic a given process can handle (throughput), but due to CRuby's
-# Global VM Lock (GVL) it has diminishing returns and will degrade the
-# response time (latency) of the application.
-#
-# The default is set to 3 threads as it's deemed a decent compromise between
-# throughput and latency for the average Rails application.
-#
-# Any libraries that use a connection pool or another resource pool should
-# be configured to provide at least as many connections as the number of
-# threads. This includes Active Record's `pool` parameter in `database.yml`.
 threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 threads threads_count, threads_count
 
-# Specifies the `port` that Puma will listen on to receive requests; default is 3000.
-port ENV.fetch("PORT", 3000)
+# port ENV.fetch("PORT", 3000)
 
-# Allow puma to be restarted by `bin/rails restart` command.
+port_env = ENV.fetch("PORT", 3000)
+bind "tcp://0.0.0.0:#{port_env}"
+
 plugin :tmp_restart
 
-# Specify the PID file. Defaults to tmp/pids/server.pid in development.
-# In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get :up, to: proc { [200, { 'Content-Type' => 'text/plain' }, ['ok']] }
   namespace :api do
     resources :bookmarks, only: [:create]
     resource :identity, only: [:show]
@@ -8,5 +9,8 @@ Rails.application.routes.draw do
         get :status
       end
     end
+
+    resource :registration, only: [:create]
+    resource :session, only: [:create, :destroy]
   end
 end

--- a/api/db/migrate/20250917092522_create_user_credentials.rb
+++ b/api/db/migrate/20250917092522_create_user_credentials.rb
@@ -1,0 +1,11 @@
+class CreateUserCredentials < ActiveRecord::Migration[8.0]
+  def change
+    create_table :user_credentials do |t|
+      t.references :user, null: false, foreign_key: true, index: { unique: true }
+      t.string :email, null: false, limit: 255
+      t.string :encrypted_password, null: false, limit: 60
+      t.timestamps null: false
+    end
+    add_index :user_credentials, :email, unique: true
+  end
+end

--- a/api/db/migrate/20250920080931_rename_encrypted_password_to_password_digest.rb
+++ b/api/db/migrate/20250920080931_rename_encrypted_password_to_password_digest.rb
@@ -1,0 +1,5 @@
+class RenameEncryptedPasswordToPasswordDigest < ActiveRecord::Migration[8.0]
+  def change
+    rename_column :user_credentials, :encrypted_password, :password_digest
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_08_14_125246) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_20_080931) do
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "address", null: false
@@ -20,6 +20,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_14_125246) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["place_id"], name: "index_places_on_place_id", unique: true
+  end
+
+  create_table "user_credentials", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "email", null: false
+    t.string "password_digest", limit: 60, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_user_credentials_on_email", unique: true
+    t.index ["user_id"], name: "index_user_credentials_on_user_id", unique: true
   end
 
   create_table "user_visits", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -64,6 +74,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_08_14_125246) do
     t.index ["user_id"], name: "index_wishlists_on_user_id"
   end
 
+  add_foreign_key "user_credentials", "users"
   add_foreign_key "user_visits", "users"
   add_foreign_key "video_view_places", "places"
   add_foreign_key "video_view_places", "video_views"

--- a/api/entrypoint.sh
+++ b/api/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -e
-
-# Remove a potentially pre-existing server.pid for Rails.
-rm -f /app/tmp/pids/server.pid
-
-# Then exec the container's main process (what's set as CMD in the Dockerfile).
-exec "$@"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,10 +1,11 @@
 services:
 
   api:
-    build: ./api
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    build:
+      context: ./api
+      target: dev
     ports:
-      - 3000:3000
+      - "3000:3000"
     volumes:
       - ./api:/app
       - gem_data:/usr/local/bundle

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -21,6 +21,10 @@
     "import/prefer-default-export": "off",
     "no-console": ["warn", { "allow": ["warn", "error"] }],
     "no-alert": "warn",
-    "react/no-unstable-nested-components": "warn"
+    "react/no-unstable-nested-components": "warn",
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      { "assert": "htmlFor", "depth": 5 }
+    ]
   }
 }

--- a/front/package.json
+++ b/front/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint .",
+    "lint": "eslint \"src/**/*.{js,jsx}\"",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -3,9 +3,11 @@ import "./App.css";
 import TopLayout from "./components/layouts/TopLayout";
 import MainLayout from "./components/layouts/MainLayout";
 import TopPage from "./pages/TopPage";
-import Homepage from "./pages/HomePage";
+import HomePage from "./pages/HomePage";
 import SearchResultPage from "./pages/SearchResultPage";
 import VideoDetailPage from "./pages/VideoDetailPage";
+import LoginPage from "./pages/LoginPage";
+import RegisterPage from "./pages/RegisterPage";
 
 function App() {
   return (
@@ -13,7 +15,9 @@ function App() {
       <Routes>
         <Route element={<TopLayout />}>
           <Route path="/" element={<TopPage />} />
-          <Route path="/home" element={<Homepage />} />
+          <Route path="/home" element={<HomePage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
         </Route>
         <Route element={<MainLayout />}>
           <Route path="/search" element={<SearchResultPage />} />

--- a/front/src/api/identity.js
+++ b/front/src/api/identity.js
@@ -1,16 +1,10 @@
-import { apiFetchJson, __setVisitorToken } from "./client";
-
+import { apiFetchJson } from "./client";
 const base = import.meta.env.VITE_API_BASE_URL || "";
 
 export async function fetchIdentity() {
-  // { user_id, token } → { userId, token } に変換されて返る
-  return apiFetchJson(`${base}/api/identity`);
+  return apiFetchJson(`${base}/api/identity`, { method: "GET" });
 }
 
 export async function ensureVisitor() {
-  const existing = localStorage.getItem("visitor_token");
-  if (existing) return { token: existing };
-  const data = await fetchIdentity();
-  if (data?.token) __setVisitorToken(data.token);
-  return data;
+  return apiFetchJson(`${base}/api/identity?ensure=1`, { method: "GET" });
 }

--- a/front/src/api/identity.js
+++ b/front/src/api/identity.js
@@ -1,4 +1,5 @@
 import { apiFetchJson } from "./client";
+
 const base = import.meta.env.VITE_API_BASE_URL || "";
 
 export async function fetchIdentity() {

--- a/front/src/api/registrations.js
+++ b/front/src/api/registrations.js
@@ -1,0 +1,10 @@
+import { apiFetchJson } from "./client";
+
+const base = import.meta.env.VITE_API_BASE_URL || "";
+
+export async function register(email, password, passwordConfirmation) {
+  return apiFetchJson(`${base}/api/registration`, {
+    method: "POST",
+    body: { email, password, password_confirmation: passwordConfirmation },
+  });
+}

--- a/front/src/api/sessions.js
+++ b/front/src/api/sessions.js
@@ -1,0 +1,14 @@
+import { apiFetchJson } from "./client";
+
+const base = import.meta.env.VITE_API_BASE_URL || "";
+
+export async function login(email, password) {
+  return apiFetchJson(`${base}/api/session`, {
+    method: "POST",
+    body: { email, password },
+  });
+}
+
+export async function logout() {
+  return apiFetchJson(`${base}/api/session`, { method: "DELETE" });
+}

--- a/front/src/pages/LoginPage.jsx
+++ b/front/src/pages/LoginPage.jsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { login, logout } from "../api/sessions";
+import { fetchIdentity } from "../api/identity";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [msg, setMsg] = useState("");
+
+  const onLogin = async (e) => {
+    e.preventDefault();
+    setMsg("");
+    try {
+      await login(email, password);
+      await fetchIdentity();
+      setMsg("ログインしました");
+    } catch (err) {
+      const code = err?.data?.error || "unknown";
+      const jp = { invalid_credentials: "メールまたはパスワードが違います" };
+      setMsg(jp[code] || `ログインに失敗しました (${code})`);
+    }
+  };
+  const onLogout = async () => {
+    setMsg("");
+    try {
+      await logout();
+      await fetchIdentity();
+      setMsg("ログアウトしました");
+    } catch (err) {
+      setMsg("ログアウトに失敗しました");
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: 420 }}>
+      <h2>ログイン</h2>
+      <form onSubmit={onLogin}>
+        <label>メールアドレス</label>
+        <input value={email} onChange={(e) => setEmail(e.target.value)} required />
+        <label>パスワード</label>
+        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        <button type="submit">ログイン</button>
+      </form>
+      <hr />
+      <button onClick={onLogout}>ログアウト</button>
+      <p>{msg}</p>
+    </div>
+  );
+}

--- a/front/src/pages/LoginPage.jsx
+++ b/front/src/pages/LoginPage.jsx
@@ -35,14 +35,14 @@ export default function LoginPage() {
     <div style={{ maxWidth: 420 }}>
       <h2>ログイン</h2>
       <form onSubmit={onLogin}>
-        <label>メールアドレス</label>
-        <input value={email} onChange={(e) => setEmail(e.target.value)} required />
-        <label>パスワード</label>
-        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        <label htmlFor="login-email">メールアドレス</label>
+        <input id="login-email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        <label htmlFor="login-password">パスワード</label>
+        <input id="login-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
         <button type="submit">ログイン</button>
       </form>
       <hr />
-      <button onClick={onLogout}>ログアウト</button>
+      <button type="button" onClick={onLogout}>ログアウト</button>
       <p>{msg}</p>
     </div>
   );

--- a/front/src/pages/RegisterPage.jsx
+++ b/front/src/pages/RegisterPage.jsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { register } from "../api/registrations";
+import { fetchIdentity } from "../api/identity";
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [password2, setPassword2] = useState("");
+  const [msg, setMsg] = useState("");
+
+  const onSubmit = async (e) => {
+    e.preventDefault();
+    setMsg("");
+    try {
+      await register(email, password, password2);
+      await fetchIdentity();
+      setMsg("登録が完了しました。");
+    } catch (err) {
+      const code = err?.data?.error || "unknown";
+      const jp = {
+        already_registered: "すでに登録済みです",
+        password_confirmation_mismatch: "パスワード（確認）が一致しません",
+        weak_password: "パスワードは8文字以上にしてください",
+        email_unavailable: "このメールアドレスは使用できません",
+        invalid_parameters: "入力内容を確認してください",
+      };
+      setMsg(jp[code] || `登録に失敗しました (${code})`);
+    }
+  };
+  return (
+    <form onSubmit={onSubmit} style={{ maxWidth: 420 }}>
+      <h2>アカウント作成</h2>
+      <label>メールアドレス</label>
+      <input value={email} onChange={(e) => setEmail(e.target.value)} required />
+      <label>パスワード</label>
+      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+      <label>パスワード（確認）</label>
+      <input type="password" value={password2} onChange={(e) => setPassword2(e.target.value)} required />
+      <button type="submit">登録</button>
+      <p>{msg}</p>
+    </form>
+  );
+}

--- a/front/src/pages/RegisterPage.jsx
+++ b/front/src/pages/RegisterPage.jsx
@@ -30,12 +30,12 @@ export default function RegisterPage() {
   return (
     <form onSubmit={onSubmit} style={{ maxWidth: 420 }}>
       <h2>アカウント作成</h2>
-      <label>メールアドレス</label>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} required />
-      <label>パスワード</label>
-      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
-      <label>パスワード（確認）</label>
-      <input type="password" value={password2} onChange={(e) => setPassword2(e.target.value)} required />
+      <label htmlFor="reg-email">メールアドレス</label>
+      <input id="reg-email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+      <label htmlFor="reg-password">パスワード</label>
+      <input id="reg-password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+      <label htmlFor="reg-password2">パスワード（確認）</label>
+      <input id="reg-password2" type="password" value={password2} onChange={(e) => setPassword2(e.target.value)} required />
       <button type="submit">登録</button>
       <p>{msg}</p>
     </form>

--- a/front/src/pages/TopPage.jsx
+++ b/front/src/pages/TopPage.jsx
@@ -6,7 +6,6 @@ function TopPage() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState("");
-  const [notice, setNotice] = useState("");
 
   const handleStart = async () => {
     try {
@@ -58,7 +57,7 @@ function TopPage() {
           border: "2px solid #2CA478",
           fontWeight: 700,
         }}
-        onClick={() => setNotice("（将来）ユーザー登録は準備中です")}
+        onClick={() => navigate("/register")}
       >
         ユーザー登録
       </button>
@@ -74,7 +73,7 @@ function TopPage() {
           color: "#fff",
           fontWeight: 700,
         }}
-        onClick={() => setNotice("（将来）ログインは準備中です")}
+        onClick={() => navigate("/login")}
       >
         ログイン
       </button>
@@ -82,11 +81,6 @@ function TopPage() {
       {errorMsg && (
         <p role="alert" style={{ marginTop: 12, color: "#b00020" }}>
           {errorMsg}
-        </p>
-      )}
-      {notice && (
-        <p role="status" aria-live="polite" style={{ marginTop: 8, color: "#555" }}>
-          {notice}
         </p>
       )}
 


### PR DESCRIPTION
## 概要

- 既存の visitor_token（UserVisit）方式は維持しつつ、メール+パスワードの本登録／ログイン／ログアウトを追加
- パスワード管理を has_secure_password へ移行（encrypted_password → password_digest にリネーム）。

## 変更内容

1. DB
　user_credentials.encrypted_password → password_digest にリネーム
2. API
- `IdentifiesUser`
    - 既定：**受動識別**（トークンがあれば特定、なければ作らない）
    - 必要時：`ensure_visitor` で**能動発行**
- `GET /api/identity`
    - 既定は状態確認のみ。**`?ensure=1` でゲスト発行**し、`X-Visitor-Token` を返却。
- `POST /api/registration`
    - `current_user` がなければ `ensure_visitor` を実行（初訪問でのダイレクト登録を許容）。
    - `has_secure_password` により `password_confirmation` 等の検証をモデルに集約。
    - 既存のエラーコード（`email_unavailable`, `weak_password`, など）を踏襲。
- `POST /api/session`（ログイン）
    - 認証成功時に **UserVisit.token を新規UUIDに置換**し、ヘッダ `X-Visitor-Token` を返却。
- `DELETE /api/session`（ログアウト）
    - 現トークンの UserVisit を削除（無効化）。
3. フロント
- アプリ起動時の**自動ゲスト発行を廃止**。
    
    トップの「さっそく使ってみる」でのみ `/api/identity?ensure=1` を叩いて**初回発行**。
    
- 登録／ログイン／ログアウト後に `fetchIdentity()` を叩いてUIを同期。
    
    （`apiFetchJson` はレスポンスヘッダの `X-Visitor-Token` を自動保存）

## 動作確認
1. トップ表示 → 何も作成されないこと（DBの users / user_visits が増えない）。
2. 「さっそく使ってみる」→ `/api/identity?ensure=1` → `X-Visitor-Token` が保存される。
3. 登録 → `user_credentials` が作成され、同じ `users` が会員化される。
5. ログイン → `UserVisit.token` が置換され、ヘッダのトークンも更新される。
6. ログアウト → 該当 `UserVisit` が削除され、以降のトークンは無効。
7. 初訪問での**登録だけ**でも成功すること（`current_user.nil?` の場合に ensure が走る）。