### PR TITLE
feat(ui): fluid layout foundation — safe-area aware snap points & map fill; fix desktop overflow

### DIFF
--- a/front/src/App.css
+++ b/front/src/App.css
@@ -1,8 +1,36 @@
+:root {
+  --page-pad-inline: clamp(12px, 4vw, 32px);
+  --header-h: 64px;
+  --bottom-bar-h: 40px;
+}
+
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}
+
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  /* padding: 2rem; */
+  width: 100%;
+  margin: 0;
+  text-align: initial;
+}
+
+.full-bleed {
+  padding-inline: 0 !important;
+}
+
+.centered {
+  display: grid;
+  place-items: center;
   text-align: center;
+}
+
+.container {
+  max-width: 1200px;
+  margin-inline: auto;
+  padding-inline: var(--page-pad-inline);
 }
 
 .logo {

--- a/front/src/components/Header.jsx
+++ b/front/src/components/Header.jsx
@@ -5,9 +5,11 @@ function Header() {
     <header
       style={{
         backgroundColor: "#eee",
-        padding: "10px",
+        padding: "1.5% 4%",
         display: "flex",
-        justifyContent: "space-between"
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "2%"
       }}>
       <h1>VloMaPlan</h1>
       <SearchBar />

--- a/front/src/components/MapPopup.jsx
+++ b/front/src/components/MapPopup.jsx
@@ -10,7 +10,8 @@ function MapPopup({
   return (
     <div
       style={{
-        width: "240px",
+        width: "50vw",
+        maxWidth: "480px",
         borderRadius: "16px",
         overflow: "hidden",
         fontFamily: "sans-serif",

--- a/front/src/components/MapSearchBar.jsx
+++ b/front/src/components/MapSearchBar.jsx
@@ -1,17 +1,29 @@
 function MapSearchBar({ onFocus }) {
   return (
-    <div style={{ display: "flex"}}>
+    <div
+      style={{
+        height: "var(--bottom-bar-h)",
+        boxSizing: "content-box",
+        paddingBottom: "env(safe-area-inset-bottom, 0px)",
+        display: "flex",
+        alignItems: "center",
+        gap: 8,
+        padding: 8,
+      }}
+    >
       <input
         type="text"
         onFocus={onFocus}
         placeholder="行きたい場所をお気に入りに追加"
         style={{
+          height: "100%",
           width: "100%",
           boxSizing: "border-box",
-          padding: "10px",
-          fontSize: "16px",
+          padding: "0 12px",
+          paddingBlock: 8,
+          fontSize: 16,
           border: "1px solid #ccc",
-          borderRadius: "8px",
+          borderRadius: 8,
         }}
         readOnly
       />

--- a/front/src/components/PlaceDetailCard.jsx
+++ b/front/src/components/PlaceDetailCard.jsx
@@ -9,25 +9,30 @@ export default function PlaceDetailCard({
   onClose,
   variant = "overlay",
   onRootClick,
-  thumbWidth = 120,
-  thumbHeight = 100,
+  thumbWidth = "28%",
+  thumbHeight,
+  // 追加：オーバーレイ時の“下からの持ち上げ量”
+  overlayOffset = "clamp(24px, 5vh, 56px)",
 }) {
   if (!place) return null;
+
+  const thumbW = typeof thumbWidth === "number" ? `${thumbWidth}px` : thumbWidth;
+  const thumbH = typeof thumbHeight === "number" ? `${thumbHeight}px` : thumbHeight;
 
   const isOverlay = variant === "overlay";
 
   const containerStyle = isOverlay
     ? {
         position: "absolute",
-        left: 12,
-        right: 12,
-        bottom: "calc(env(safe-area-inset-bottom, 0px) + 40px)",
+        left: "2.5%",
+        right: "2.5%",
+        bottom: `calc(env(safe-area-inset-bottom, 0px) + ${overlayOffset})`,
         background: "#fff",
         borderRadius: 16,
         boxShadow: "0 10px 24px rgba(0,0,0,.2)",
         zIndex: 3000,
         display: "grid",
-        gridTemplateColumns: `1fr ${thumbWidth}px`,
+        gridTemplateColumns: `1fr ${thumbW}`,
         gap: 12,
         padding: 12,
       }
@@ -36,7 +41,7 @@ export default function PlaceDetailCard({
         borderRadius: 12,
         border: "1px solid #eee",
         display: "grid",
-        gridTemplateColumns: `1fr ${thumbWidth}px`,
+        gridTemplateColumns: `1fr ${thumbW}`,
         gap: 12,
         padding: 10,
         cursor: onRootClick ? "pointer" : "default",
@@ -201,7 +206,7 @@ export default function PlaceDetailCard({
       <div
         style={{
           width: "100%",
-          height: thumbHeight,
+          height: thumbH,
           borderRadius: 12,
           background: "#e9e9e9",
           display: "flex",
@@ -223,7 +228,6 @@ export default function PlaceDetailCard({
     </>
   );
 
-  // ★ onRootClick あり：role/tabIndex/keyboard を “リテラル” で付けたブランチ
   if (onRootClick) {
     return (
       <div
@@ -246,6 +250,5 @@ export default function PlaceDetailCard({
     );
   }
 
-  // ★ onRootClick なし：完全にプレーンな div（クリック/タブ不可）
   return <div style={containerStyle}>{renderContent()}</div>;
 }

--- a/front/src/components/TopHeader.jsx
+++ b/front/src/components/TopHeader.jsx
@@ -3,9 +3,11 @@ function TopHeader() {
     <header
       style={{
         backgroundColor: "#eee",
-        padding: "10px",
+        padding: "1.5% 4%",
         display: "flex",
-        justifyContent: "space-between"
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: "2%"
       }}>
       <h1>VloMaPlan</h1>
       <h1>Menu</h1>

--- a/front/src/components/layouts/DesktopLayout.jsx
+++ b/front/src/components/layouts/DesktopLayout.jsx
@@ -7,15 +7,29 @@ function DesktopLayout({ id, relatedVideos, channels, position }) {
   const navigate = useNavigate();
 
   return (
-    <div style={{ display: "flex", flexDirection: "row", height: "100vh" }}>
-      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
-        <h2>動画再生ページ</h2>
-        <div style={{ flex: "0 0 300px" }}>
+    <div
+      className="layout-desktop"
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1fr 1fr",
+        gap: "2%",
+        height: "100dvh",
+      }}
+    >
+      <section
+        style={{
+          minWidth: 0,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <div style={{ width: "100%", aspectRatio: "16/9" }}>
           <VideoPlayerWrapper videoId={id} />
         </div>
 
-        <h3>関連動画</h3>
-        <div style={{ flex: 1, overflowY: "auto" }}>
+        <h3 style={{ marginTop: "1rem" }}>関連動画</h3>
+        <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
           {relatedVideos.map((video) => (
             <VideoItem
               key={video.id}
@@ -25,11 +39,19 @@ function DesktopLayout({ id, relatedVideos, channels, position }) {
             />
           ))}
         </div>
-      </div>
+      </section>
 
-      <div style={{ width: "400px", marginLeft: "16px", height: "100vh" }}>
-        <MapPreview position={position} />
-      </div>
+      <aside
+        style={{
+          minWidth: 0,
+          minHeight: 0,
+          height: "100%",
+        }}
+      >
+        <div style={{ position: "relative", width: "100%", height: "100%" }}>
+          <MapPreview position={position} />
+        </div>
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- **PCで画面幅が狭い時**や**モバイル端末での表示時**にシートが実際の画面より大きく見積もられ、**下に見切れる／溢れる**問題を解消。
- 下固定の検索バーぶんの余白が**親子で二重で確保している状態**になっていたため整理。**Map 下端**と**オーバーレイ**（PlaceDetailCard / Wishlist）の見切れを解消。
- **数秒後にシートのサイズが変わる**現象（`visualViewport.scroll` 監視による再計算）を廃止し、スナップ高さを**安定化**。

## 変更内容

### `front/src/components/layouts/MobileLayout.jsx`
- シートのスナップを**配列 state**（例：`[full, mid]`）で渡す実装に変更。
  - `full` = `document.documentElement.clientHeight`（最優先/PC安定）→ `visualViewport.height` → `window.innerHeight` の順で取得し、  
    `--header-h` と `SLOP(24px)` を引いた**はみ出さない最大値**に。
  - `mid` は `min(400, full * 0.6)` で操作しやすい中段に設定。
- **監視イベント**は `resize` のみに限定（`visualViewport.scroll` は廃止）し、**数秒後のドリフトを解消**。
- シートを**開いた直後だけ**一度再計算して、初期表示のズレを防止。
- `Sheet.Content` を **`display: grid; grid-template-rows: 1fr auto;`** にし、  
  1行目：Map を **1fr で常時フィット**、2行目：**`max(env(safe-area-inset-bottom,0px),16px)`** のスペーサー。
- ページ本体は **シート閉時のみ** 下固定バーぶんの余白を確保：  
  `padding-bottom: calc(var(--bottom-bar-h) + env(safe-area-inset-bottom, 0px))`。  
  シート表示中は `padding-bottom: 0`。
- 検索バーのラッパー（固定配置）から余分な `padding` を削除（高さは `MapSearchBar` 側で一元管理）。

### `front/src/components/MapSearchBar.jsx`
- ラッパー高さを **`height: var(--bottom-bar-h)`** に統一。  
- **縦方向の余白は input 内側**（`padding-block`）で持たせ、ラッパーは**`paddingInline: 16px` のみ**。  
- **safe-area** はラッパー側の `padding-bottom: env(safe-area-inset-bottom, 0px)` で付与。  
  → 親の `padding-bottom` と役割が重ならず、**常に一定の見た目**に。

### `front/src/components/MapPreview.jsx`
- デフォルトの高さ管理を **`height: 100%`**（親の 1fr グリッドにフィット）に統一。  
  `mapHeight` が渡された場合は後方互換として尊重。
- 右上アクションやポップアップの **z-index** を整理。
- **WishlistPanel** と **PlaceDetailCard** は**下から少し浮かせる**：  
  `bottom: clamp(env(safe-area-inset-bottom, 0px), 16px, 32px)`（見切れ予防 & 端末安全域に追従）。

### `front/src/components/PlaceDetailCard.jsx`
- オーバーレイ表示時の下端を  
  `bottom: clamp(env(safe-area-inset-bottom, 0px), 16px, 32px)` に変更し、**常に少し上**で安定表示。

### `front/src/components/MapPopup.jsx`
- シート/Map オーバーレイとの**重なり順**の干渉を回避（`z-index` 微調整）。

### `front/src/components/layouts/DesktopLayout.jsx`
- モバイル側の修正と干渉しない範囲で**重なり順や余白**を微調整（視覚的不整合を予防）。

### `front/src/components/Header.jsx` / `TopHeader.jsx`
- 実際のヘッダー高に合わせて **`--header-h`** を参照する前提に整理（スタイルの一貫性を担保）。

### `front/src/App.css`
- 新規 CSS 変数 **`--bottom-bar-h`** を追加（例：`56px`）。  
- `html, body, #root` の `height: 100%` を維持して `100dvh` 系と整合。  
- 変数一覧：
  - `--header-h: 64px;`
  - `--bottom-bar-h: 56px;`（下固定バーの論理高さ）


## 動作確認
1. **PC狭幅**で `/video/:id` を表示 → 検索バーにフォーカスしてシート表示。  
   - 最大スナップ（full）でも**下に溢れない**こと。  
   - **ウィンドウサイズ変更**時にスナップが**適切に再計算**されること。
2. **モバイル（iOS/Android）**で `/video/:id` → シートを開閉。  
   - 表示から**数秒後**でもシート下端が**ズレない**こと（`visualViewport.scroll` 非監視の効果）。  
   - Map が **1fr でシート内にピッタリ**収まっていること。
3. **お気に入り追加**後に表示される **PlaceDetailCard** が**見切れず**下端に程よい余白で表示されること。  
   **WishlistPanel** も見切れないこと。
4. **下固定の検索バー**高さが `--bottom-bar-h` と一致し、  
   **シート閉時のみ** ページ下部に `calc(var(--bottom-bar-h) + safe-area)` の余白が確保されること（**二重取りなし**）。
5. Notch 端末で **safe-area**（`env(safe-area-inset-bottom)`）が効き、UI が重ならないこと。
6. Map 上のオーバーレイ（ポップアップ等）の **重なり順**が正しく、操作に支障がないこと。
