### PR TITLE
feat(auth): introduce AuthContext, rotate session token on registration, and toggle header Menu↔Logout

### DIFF
--- a/api/app/controllers/api/identities_controller.rb
+++ b/api/app/controllers/api/identities_controller.rb
@@ -2,9 +2,17 @@ class Api::IdentitiesController < ApplicationController
   def show
     ensure_visitor if params[:ensure].present? && current_user.nil?
 
+    response.set_header('X-Visitor-Token', visitor_token) if visitor_token.present?
+
+    is_registered =
+      if current_user
+        current_user.respond_to?(:user_credential) ? current_user.user_credential.present? : false
+      else
+        false
+      end
+
     render json: {
-      user_id: current_user.id,
-      token: visitor_token
+      registered: is_registered
     }
   end
 end

--- a/api/app/controllers/api/registrations_controller.rb
+++ b/api/app/controllers/api/registrations_controller.rb
@@ -8,7 +8,13 @@ class Api::RegistrationsController < ApplicationController
       uc = current_user.build_user_credential(registration_params)
       uc.save!
 
-      render json: { ok: true, user_id: current_user.id, email: uc.email }, status: :created
+      uv = UserVisit.find_or_initialize_by(user: current_user)
+      uv.token = SecureRandom.uuid
+      uv.created_at ||= Time.current
+      uv.save!
+      response.set_header("X-Visitor-Token", uv.token)
+
+      render json: { ok: true }, status: :created
     end
   rescue ActiveRecord::RecordInvalid => e
     render json: { error: map_registration_error(e.record) }, status: :unprocessable_entity

--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -6,21 +6,24 @@ import TopPage from "./pages/TopPage";
 import SearchResultPage from "./pages/SearchResultPage";
 import VideoDetailPage from "./pages/VideoDetailPage";
 import MyPage from "./pages/MyPage";
+import { AuthProvider } from "./contexts/AuthContext";
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<TopLayout />}>
-          <Route path="/" element={<TopPage />} />
-          <Route path="mypage" element={<MyPage />} />
-        </Route>
-        <Route element={<MainLayout />}>
-          <Route path="/search" element={<SearchResultPage />} />
-          <Route path="/video/:id" element={<VideoDetailPage />} />
-        </Route>
-      </Routes>
-    </Router>
+    <AuthProvider>
+      <Router>
+        <Routes>
+          <Route element={<TopLayout />}>
+            <Route path="/" element={<TopPage />} />
+            <Route path="mypage" element={<MyPage />} />
+          </Route>
+          <Route element={<MainLayout />}>
+            <Route path="/search" element={<SearchResultPage />} />
+            <Route path="/video/:id" element={<VideoDetailPage />} />
+          </Route>
+        </Routes>
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/front/src/components/Header.jsx
+++ b/front/src/components/Header.jsx
@@ -1,4 +1,5 @@
 import SearchBar from "./SearchBar";
+import UserMenuOrLogout from "./UserMenuOrLogout";
 
 function Header() {
   return (
@@ -13,7 +14,7 @@ function Header() {
       }}>
       <h1>VloMaPlan</h1>
       <SearchBar />
-      <h1>Menu</h1>
+      <UserMenuOrLogout />
     </header>
   )
 }

--- a/front/src/components/LoginOverlay.jsx
+++ b/front/src/components/LoginOverlay.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { login } from "../api/sessions";
-import { fetchIdentity } from "../api/identity";
+import { useAuth } from "../contexts/AuthContext";
 
 export default function LoginOverlay({ onClose, onSwitchToRegister }) {
   const navigate = useNavigate();
+  const { refresh } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
@@ -28,9 +29,9 @@ export default function LoginOverlay({ onClose, onSwitchToRegister }) {
     setSubmitting(true);
     try {
       await login(email, password);
-      await fetchIdentity();
+      await refresh();
       onClose();
-      navigate("/mypage");
+      navigate("/mypage", { replace: true });
     } catch (err) {
       const code = err?.data?.error || "unknown";
       const jp = { invalid_credentials: "メールまたはパスワードが違います" };

--- a/front/src/components/RegisterOverlay.jsx
+++ b/front/src/components/RegisterOverlay.jsx
@@ -1,11 +1,10 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { register } from "../api/registrations";
-import { fetchIdentity } from "../api/identity";
-
+import { useAuth } from "../contexts/AuthContext";
 export default function RegisterOverlay({ onClose, onSwitchToLogin }) {
   const navigate = useNavigate();
-
+  const { refresh } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [password2, setPassword2] = useState("");
@@ -40,9 +39,9 @@ export default function RegisterOverlay({ onClose, onSwitchToLogin }) {
     setSubmitting(true);
     try {
       await register(email, password, password2);
-      await fetchIdentity();
+      await refresh();
       onClose();
-      navigate("/mypage");
+      navigate("/mypage", { replace: true });
     } catch (err) {
       const code = err?.data?.error || "unknown";
       const jp = {

--- a/front/src/components/TopHeader.jsx
+++ b/front/src/components/TopHeader.jsx
@@ -1,3 +1,5 @@
+import UserMenuOrLogout from "./UserMenuOrLogout";
+
 function TopHeader() {
   return (
     <header
@@ -10,7 +12,7 @@ function TopHeader() {
         gap: "2%"
       }}>
       <h1>VloMaPlan</h1>
-      <h1>Menu</h1>
+      <UserMenuOrLogout />
     </header>
   )
 }

--- a/front/src/components/UserMenuOrLogout.jsx
+++ b/front/src/components/UserMenuOrLogout.jsx
@@ -1,0 +1,37 @@
+import { useNavigate } from "react-router-dom";
+import { logout } from "../api/sessions";
+import { useAuth } from "../contexts/AuthContext";
+
+export default function UserMenuOrLogout() {
+  const { identity, refresh } = useAuth();
+  const navigate = useNavigate();
+
+  const onLogout = async () => {
+    try {
+      await logout();
+    } finally {
+      await refresh();
+      navigate("/");
+    }
+  };
+
+  if (identity?.registered) {
+    return (
+      <button
+        type="button"
+        onClick={onLogout}
+        style={{
+          padding: "8px 14px",
+          borderRadius: 999,
+          border: "1px solid #999",
+          background: "white",
+          cursor: "pointer",
+        }}
+      >
+        ログアウト
+      </button>
+    );
+  }
+
+  return <h1>Menu</h1>;
+}

--- a/front/src/contexts/AuthContext.jsx
+++ b/front/src/contexts/AuthContext.jsx
@@ -1,0 +1,46 @@
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { fetchIdentity } from "../api/identity";
+import { TOKEN_KEY } from "../api/client";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [identity, setIdentity] = useState({ registered: false, loading: true });
+
+  const refresh = useCallback(async () => {
+    try {
+      const data = await fetchIdentity();
+      setIdentity({ registered: !!data?.registered, loading: false });
+    } catch {
+      setIdentity({ registered: false, loading: false });
+    }
+  }, []);
+
+  useEffect(() => { refresh(); }, [refresh]);
+
+  useEffect(() => {
+    const onTokenChanged = () => { refresh(); };
+    window.addEventListener("auth:token-changed", onTokenChanged);
+    return () => window.removeEventListener("auth:token-changed", onTokenChanged);
+  }, [refresh]);
+
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (e.key === TOKEN_KEY) refresh();
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, [refresh]);
+
+  return (
+    <AuthContext.Provider value={{ identity, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}


### PR DESCRIPTION
## 概要
- `/api/identity` の返却を **`{ registered }` のみに変更**。
- **ユーザー登録直後にセッショントークンをローテーション**し、レスポンスヘッダー `X-Visitor-Token` 経由で新トークンを配布。
- フロントに **AuthContext** を導入して認証状態をアプリ全体に配布。トークン変更イベントおよび `localStorage` 変更で **自動的に `refresh()`** され、ヘッダーの **Menu ↔ ログアウト** が即時反映されるように修正。

## 変更内容
### Backend
- `api/app/controllers/api/identities_controller.rb`
  - レスポンスを **`{ registered: boolean }` のみ**に変更。
  - 既存の `ensure_visitor` ポリシーは維持。
  - 必要時は `X-Visitor-Token` をレスポンスヘッダーに設定。
- `api/app/controllers/api/registrations_controller.rb`
  - **登録成功時に `UserVisit` のトークンをローテーション**して保存。
  - 新トークンを **`X-Visitor-Token`** で返却（フロントが自動保存）。

### Frontend
- `front/src/api/client.js`
  - レスポンスから `X-Visitor-Token` を検知して保存し、**変化時は `auth:token-changed` を dispatch**。
- `front/src/contexts/AuthContext.jsx`（新規）
  - 初回に `/api/identity` を取得し、`registered` を保持。
  - `auth:token-changed` と `storage` イベントを購読し、**自動 `refresh()`**。
- `front/src/components/UserMenuOrLogout.jsx`（新規）
  - `useAuth()` で `registered` を参照し、**未ログイン: Menu / ログイン: ログアウトボタン** を出し分け。
  - ログアウト後に `refresh()` → `/` へ遷移。
- `front/src/components/TopHeader.jsx` / `front/src/components/Header.jsx`
  - 右端を `UserMenuOrLogout` に差し替え。
- `front/src/components/LoginOverlay.jsx` / `front/src/components/RegisterOverlay.jsx`
  - **`await login/register → await refresh() → navigate()`** の順で状態を確実に反映。
- `front/src/App.jsx`
  - ルーティング全体を **`<AuthProvider>`** でラップ。

## 動作確認
1. **未ログインでトップを開く**  
   - `/api/identity` が `{ registered:false }` を返し、ヘッダー右端が **Menu**。
2. **ログイン**（`POST /api/session`）  
   - `X-Visitor-Token` が更新され、`auth:token-changed` → `refresh()` が走る。  
   - ヘッダーが **ログアウト** に即時切替（リロード不要）。
3. **ユーザー登録**（`POST /api/registrations`）  
   - レスポンスヘッダーに **新しい `X-Visitor-Token`** が付与される（Networkタブで確認）。  
   - 登録完了後にヘッダーが **ログアウト** に切替。
4. **ログアウト**（`DELETE /api/session`）  
   - `registered:false` に戻り、ヘッダーが **Menu** へ。  
   - 必要に応じて未ログイン利用を始める画面では `ensureVisitor()` を呼ぶ。
5. **複数タブ同期**  
   - 片方でログイン/ログアウトした際、もう一方のタブでも **自動で表示が切り替わる**（`storage` イベント連動）。