### PR TITLE
feat(auth, ui, yt): protect /mypage; improve signup flow; prefer hi-res thumbnails; stabilize light theme

### DIFF
--- a/front/src/App.jsx
+++ b/front/src/App.jsx
@@ -7,6 +7,7 @@ import SearchResultPage from "./pages/SearchResultPage";
 import VideoDetailPage from "./pages/VideoDetailPage";
 import MyPage from "./pages/MyPage";
 import { AuthProvider } from "./contexts/AuthContext";
+import ProtectedRoute from "./components/routing/ProtectedRoute";
 
 function App() {
   return (
@@ -15,7 +16,14 @@ function App() {
         <Routes>
           <Route element={<TopLayout />}>
             <Route path="/" element={<TopPage />} />
-            <Route path="mypage" element={<MyPage />} />
+            <Route
+              path="mypage"
+              element={
+                <ProtectedRoute>
+                  <MyPage />
+                </ProtectedRoute>
+              }
+            />
           </Route>
           <Route element={<MainLayout />}>
             <Route path="/search" element={<SearchResultPage />} />

--- a/front/src/components/MapPreview.jsx
+++ b/front/src/components/MapPreview.jsx
@@ -12,10 +12,9 @@ import {
   deleteWishlist,
 } from "../api/wishlists";
 
-/* ==== 下部リスト（オーバーレイ） ==== */
 function WishlistPanel({
   heightPx = 280,
-  bottomOffset = "clamp(24px, 6vh, 64px)", // 追加：下からの持ち上げ量
+  bottomOffset = "clamp(24px, 6vh, 64px)",
   items,
   loading,
   hasNext,
@@ -63,7 +62,6 @@ function WishlistPanel({
         overflow: "hidden",
       }}
     >
-      {/* ヘッダー */}
       <div
         style={{
           display: "flex",
@@ -96,7 +94,6 @@ function WishlistPanel({
         </button>
       </div>
 
-      {/* リスト */}
       <div style={{ flex: 1, overflowY: "auto", padding: 12, gap: 10, display: "grid" }}>
         {items.length === 0 && !loading && <div style={{ color: "#666" }}>まだ保存がありません</div>}
 
@@ -124,19 +121,17 @@ function WishlistPanel({
   );
 }
 
-/* ================= MapPreview ================= */
 function MapPreview({
   position,
   placeName,
   selectedPlace,
   currentVideo,
   onRequestExpand,
-  mapHeight, // 後方互換：未指定なら 100%
+  mapHeight,
 }) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
 
-  // ▼ Wishlist パネル用
   const [showWishlist, setShowWishlist] = useState(false);
   const [wlItems, setWlItems] = useState([]);
   const [wlNext, setWlNext] = useState(1);
@@ -219,7 +214,6 @@ function MapPreview({
     alert(`旅行プランに追加（仮）: ${item.place?.name ?? "(no name)"}`);
   }, []);
 
-  // mapHeight 変化時のパン（後方互換）
   useEffect(() => {
     if (!map) return;
     const oldH = prevH.current;
@@ -231,7 +225,6 @@ function MapPreview({
     prevH.current = newH;
   }, [mapHeight, map]);
 
-  // 合計カウント初期化
   useEffect(() => {
     (async () => {
       try {
@@ -243,7 +236,6 @@ function MapPreview({
     })();
   }, []);
 
-  // place の保存状態とサムネ初期化
   useEffect(() => {
     const pid = selectedPlace?.placeId;
     if (!pid) return;
@@ -262,7 +254,6 @@ function MapPreview({
     })();
   }, [selectedPlace?.placeId]);
 
-  // 地図クリックなどで詳細/ポップアップ閉じ
   useEffect(() => {
     setIsPopupOpen(false);
     setShowDetail(false);
@@ -319,7 +310,6 @@ function MapPreview({
 
   return (
     <div style={{ height: containerHeight, width: "100%", position: "relative" }}>
-      {/* 右上のアクション */}
       <div
         style={{
           position: "absolute",
@@ -347,7 +337,6 @@ function MapPreview({
         />
       </div>
 
-      {/* Google Map */}
       <Map
         defaultCenter={position}
         defaultZoom={14}
@@ -397,7 +386,6 @@ function MapPreview({
         )}
       </Map>
 
-      {/* 下部の詳細カード（保存済み） */}
       {showDetail && isSavedGlobally && (
         <PlaceDetailCard
           variant="overlay"
@@ -417,12 +405,10 @@ function MapPreview({
           onClose={() => setShowDetail(false)}
           thumbWidth={120}
           thumbHeight={100}
-          // ここで少し上に浮かせる
           overlayOffset="clamp(24px, 5vh, 56px)"
         />
       )}
 
-      {/* お気に入りリスト（シート内にかぶせる） */}
       {showWishlist && (
         <WishlistPanel
           bottomOffset="clamp(24px, 6vh, 64px)"

--- a/front/src/components/RegisterOverlay.jsx
+++ b/front/src/components/RegisterOverlay.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { register } from "../api/registrations";
 import { useAuth } from "../contexts/AuthContext";
+
 export default function RegisterOverlay({ onClose, onSwitchToLogin }) {
   const navigate = useNavigate();
   const { refresh } = useAuth();

--- a/front/src/components/routing/ProtectedRoute.jsx
+++ b/front/src/components/routing/ProtectedRoute.jsx
@@ -1,0 +1,15 @@
+// front/src/components/routing/ProtectedRoute.jsx
+import { Navigate } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+
+export default function ProtectedRoute({ children }) {
+  const { identity } = useAuth();
+
+  if (identity.loading) return null;
+
+  if (!identity.registered) {
+    return <Navigate to="/" replace state={{ loginRequired: true }} />;
+  }
+
+  return children;
+}

--- a/front/src/hooks/useLoginRequiredEffect.js
+++ b/front/src/hooks/useLoginRequiredEffect.js
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+
+export function useLoginRequiredEffect(openLoginUI) {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const s = location.state;
+    if (s?.loginRequired) {
+      openLoginUI?.();
+      navigate(location.pathname, { replace: true });
+    }
+  }, [location, navigate, openLoginUI]);
+}

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -3,9 +3,9 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: light;
+  color: #111;
+  background-color: #fff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;

--- a/front/src/pages/TopPage.jsx
+++ b/front/src/pages/TopPage.jsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { ensureVisitor } from "../api/identity";
 import TopQuickStartOverlay from "../components/TopQuickStartOverlay";
 import LoginOverlay from "../components/LoginOverlay";
 import RegisterOverlay from "../components/RegisterOverlay";
+import { useLoginRequiredEffect } from "../hooks/useLoginRequiredEffect";
 
 function TopPage() {
   const [loading, setLoading] = useState(false);
@@ -10,6 +11,12 @@ function TopPage() {
   const [opening, setOpening] = useState(false);
   const [loginOpen, setLoginOpen] = useState(false);
   const [registerOpen, setRegisterOpen] = useState(false);
+
+  const openLoginUI = useCallback(() => {
+    setLoginOpen(true);
+  }, []);
+
+  useLoginRequiredEffect(openLoginUI);
 
   const handleStart = async () => {
     try {

--- a/front/src/utils/fetchYoutubeVideos.js
+++ b/front/src/utils/fetchYoutubeVideos.js
@@ -31,7 +31,12 @@ const fetchYoutubeVideos = async (keyword) => {
     .map((video) => ({
       id: video.id,
       title: video.snippet.title,
-      thumbnail: video.snippet.thumbnails.medium.url,
+      thumbnail:
+        ( video.snippet.thumbnails.maxres?.url ??
+          video.snippet.thumbnails.standard?.url ??
+          video.snippet.thumbnails.high?.url ??
+          video.snippet.thumbnails.medium?.url ??
+          `https://i.ytimg.com/vi/${video.id}/hq720.jpg`),
       channelId: video.snippet.channelId,
       duration: video.contentDetails.duration,
       viewCount: video.statistics.viewCount,


### PR DESCRIPTION
## 概要
- `/mypage` を **登録ユーザー限定** に変更し、未登録時はトップへリダイレクト＋**ログインモーダルを自動表示**。
- YouTube サムネイルは **高解像度優先**（`maxres → standard → high → medium → hq720`）で取得し、検索結果の粗さを軽減。
- **ライト配色を基準**にして、Chrome シークレット等での意図しないダーク化を抑止。

## 変更内容
- **ルーティング/認証**
  - `front/src/components/routing/ProtectedRoute.jsx`（新規）  
    - `identity.registered === true` のみ通過。未登録は `/` へ `state: { loginRequired: true }` 付きでリダイレクト。
  - `front/src/hooks/useLoginRequiredEffect.js`（新規）  
    - リダイレクト後にログインモーダルを自動オープン、`state` を即時クリア。
  - `front/src/App.jsx`  
    - ルーターを `AuthProvider` でラップ。`/mypage` を `<ProtectedRoute>` に変更。

- **トップ/サインアップ導線**
  - `front/src/pages/TopPage.jsx`  
    - `useLoginRequiredEffect` を適用（ログイン要求時にモーダル自動表示）。
  - `front/src/components/RegisterOverlay.jsx`  

- **YouTube サムネ画質**
  - `front/src/utils/fetchYoutubeVideos.js`  
    - サムネ選択を高解像度優先へ変更

- **見た目の安定化**
  - `front/src/index.css`  
    - `:root` を **ライト基準**（`color-scheme: light; background: #fff; color: #111`）に統一。  
      ※ 動作確認優先のためシークレット/ダーク自動化での白文字化・反転を一旦抑止。（のちにダークテーマ対応予定）
  - `front/src/components/MapPreview.jsx`  
    - 不要なコメントを削除

## 動作確認
1. **未ログインで `/mypage` にアクセス**  
   - `/` にリダイレクトされ、トップ表示時に **ログインモーダルが自動で開く**こと。
2. **サインアップの流れ**  
   - トップ → 「ユーザー登録」→ メール/パスワード（8文字以上）入力 → 登録成功後、**自動で `/mypage` へ遷移**すること。  
   - パスワード不一致/不足時に日本語エラーメッセージが出ること。
3. **ログイン要求フロー**  
   - `/mypage` → リダイレクト → トップでログインモーダルが開く → ログイン成功後 `/mypage` 入場できること。
4. **検索結果のサムネ画質**  
   - 検索ページで、カード幅に応じて**ボケが軽減**されていること（以前より高解像度URLに置換）。  
   - もし古いキャッシュが残る場合は `sessionStorage.clear()` もしくは別クエリで再検索。
5. **配色確認**  
   - 通常/シークレットモードともに **白背景・黒文字**が維持されること（意図しない反転が無いこと）。
