### PR TITLE
feat(desktop-layout): integrate map search overlay with wishlist and place autocomplete

### DIFF
--- a/front/src/components/MapPreview.jsx
+++ b/front/src/components/MapPreview.jsx
@@ -128,6 +128,7 @@ function MapPreview({
   currentVideo,
   onRequestExpand,
   mapHeight,
+  onUnmask,
 }) {
   const [isPopupOpen, setIsPopupOpen] = useState(false);
   const [showDetail, setShowDetail] = useState(false);
@@ -172,6 +173,7 @@ function MapPreview({
 
   const handleOpenWishlist = useCallback(async () => {
     onRequestExpand?.();
+    onUnmask?.();
     setShowWishlist(true);
     setIsPopupOpen(false);
     setShowDetail(false);
@@ -333,7 +335,10 @@ function MapPreview({
           label="旅行プランを表示"
           iconSrc={isSaved ? "/filledluggage.svg" : "/luggage.svg"}
           iconAlt="旅行プラン"
-          onAction={() => alert("旅行プラン機能は準備中です")}
+          onAction={() => {
+            onUnmask?.();
+            alert("旅行プラン機能は準備中です")
+          }}
         />
       </div>
 

--- a/front/src/components/PlaceAutocomplete.jsx
+++ b/front/src/components/PlaceAutocomplete.jsx
@@ -2,12 +2,13 @@ import { useState, useCallback } from "react";
 import { useMapsLibrary } from "@vis.gl/react-google-maps";
 import { useAutocompleteSuggestions } from "../hooks/useAutocompleteSuggestions";
 
-function PlaceAutocomplete({ onPlaceSelect }) {
+function PlaceAutocomplete({ onPlaceSelect, onSearchStart }) {
   useMapsLibrary("places");
 
   const [inputValue, setInputValue] = useState("");
   const [searchValue, setSearchValue] = useState("");
   const [isComposing, setIsComposing] = useState(false);
+  const [firedStart, setFiredStart] = useState(false);
 
   const { suggestions, resetSession } = useAutocompleteSuggestions(searchValue);
 
@@ -55,7 +56,14 @@ function PlaceAutocomplete({ onPlaceSelect }) {
         type="text"
         placeholder="行きたい場所をお気に入りに追加"
         value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
+        onChange={(e) => {
+          const v = e.target.value;
+          setInputValue(v);
+          if (!firedStart && v.trim().length > 0) {
+            setFiredStart(true);
+            onSearchStart?.();
+          }
+        }}
         onCompositionStart={handleCompositionStart}
         onCompositionEnd={handleCompositionEnd}
         onKeyDown={handleKeyDown}


### PR DESCRIPTION
## 概要
デスクトップレイアウトに「マップ検索バー」を追加。  
検索から場所を選択 → マップへ移動 → お気に入り追加・リスト表示が一連の流れで利用できるように修正。  

## 変更内容
- `DesktopLayout.jsx`
  - PlaceAutocompleteを右カラム上部に配置
  - マスク表示の切り替えを追加（検索開始前はマップをマスク表示）
- `PlaceAutocomplete.jsx`
  - オートコンプリート検索機能を追加
  - 候補リストから選択すると場所情報を取得しMapPreviewへ渡す
- `MapPreview.jsx`
  - 行きたい場所リスト（WishlistPanel）をオーバーレイ表示できるように追加
  - 選択した場所の保存・削除・旅行プラン追加（仮）処理を実装
  - totalCountの取得やwishlistステータスの反映を実装
  - ポップアップで「お気に入りに追加」確認を表示する処理を追加

## 動作確認
1. デスクトップレイアウト画面を開く  
   - 動画プレイヤーと関連動画、右カラムに検索バーとマップが表示される
2. 検索バーで場所を入力 → 候補を選択  
   - マップが選択場所へ移動し、マスクが解除される
3. マップ上のマーカーをクリック  
   - お気に入り追加ポップアップが表示され、保存後は詳細カードが表示される
4. 「行きたい場所リストを表示」ボタンをクリック  
   - Wishlistパネルがオーバーレイで表示され、スクロールで追加ロードできる
5. Wishlistアイテムの削除、旅行プランへの追加（仮）処理が動作することを確認
