### PR TITLE
feat(plan): implement Travel Plan panel UI (picker, docked panel, numbered pins)

### DIFF
--- a/front/src/api/wishlists.js
+++ b/front/src/api/wishlists.js
@@ -4,13 +4,11 @@ const base = import.meta.env.VITE_API_BASE_URL || "";
 
 export async function wishlistsStatus({ placeId }) {
   const url = new URL(`${base}/api/wishlists/status`);
-  // クエリ名はRailsに合わせてsnake_caseで送る
   url.searchParams.set("place_id", placeId);
-  return apiFetchJson(url.toString()); // ← 受信はcamelCase化される
+  return apiFetchJson(url.toString());
 }
 
 export async function totalCountWishlists() {
-  // { total_count: 0 } → { totalCount: 0 } に変換される
   return apiFetchJson(`${base}/api/wishlists/total_count`);
 }
 
@@ -21,7 +19,6 @@ export async function listWishlists({ page = 1, per = 20 } = {}) {
   return apiFetchJson(url.toString());
 }
 
-// 204 No Content想定：JSON不要なので従来のapiFetchでOK
 export async function deleteWishlist(id) {
   const res = await apiFetch(`${base}/api/wishlists/${id}`, { method: "DELETE" });
   if (!res.ok && res.status !== 204) throw new Error(`deleteWishlist failed: ${res.status}`);

--- a/front/src/components/CustomMarker.jsx
+++ b/front/src/components/CustomMarker.jsx
@@ -7,6 +7,7 @@ function CustomMarker({
   isSelected = false,
   inPlan = false,
   sortOrder = null,
+  forceNumberPin = false,
   onClick,
 }) {
   const map = useMap();
@@ -44,7 +45,25 @@ function CustomMarker({
 
     let baseEl;
 
-    if (isFavorite) {
+    if (forceNumberPin && typeof sortOrder === "number") {
+      const pin = new PinElement({
+        scale: 1.6,
+        glyph: String(sortOrder),
+        glyphColor: "#fff",
+        background: "#2ca478",
+        borderColor: "#2ca478",
+      });
+      const wrap = document.createElement("div");
+      wrap.style.width = `${SIZE}px`;
+      wrap.style.height = `${SIZE}px`;
+      wrap.style.display = "grid";
+      wrap.style.placeItems = "center";
+      wrap.style.position = "relative";
+      wrap.style.zIndex = "1";
+      wrap.appendChild(pin.element);
+      baseEl = wrap;
+
+    } else if (isFavorite) {
       const img = document.createElement("img");
       img.src = isSelected ? "/selectedfilledheart.svg" : "/filledheart.svg";
       img.alt = "お気に入り";
@@ -94,43 +113,30 @@ function CustomMarker({
 
     container.appendChild(baseEl);
 
-    if (inPlan && isFavorite) {
-      const badge = document.createElement("div");
-      badge.style.position = "absolute";
-      badge.style.right = "-2px";
-      badge.style.bottom = "-2px";
-      badge.style.width = `${BADGE_SIZE}px`;
-      badge.style.height = `${BADGE_SIZE}px`;
-      badge.style.borderRadius = `${BADGE_SIZE / 2}px`;
-      badge.style.background = "#fff";
-      badge.style.boxShadow = "0 1px 3px rgba(0,0,0,.25)";
-      badge.style.display = "grid";
-      badge.style.placeItems = "center";
-      badge.style.zIndex = "2";
+    if (!(forceNumberPin && typeof sortOrder === "number")) {
+      if (inPlan && isFavorite) {
+        const badge = document.createElement("div");
+        badge.style.position = "absolute";
+        badge.style.right = "-2px";
+        badge.style.bottom = "-2px";
+        badge.style.width = `${BADGE_SIZE}px`;
+        badge.style.height = `${BADGE_SIZE}px`;
+        badge.style.borderRadius = `${BADGE_SIZE / 2}px`;
+        badge.style.background = "#fff";
+        badge.style.boxShadow = "0 1px 3px rgba(0,0,0,.25)";
+        badge.style.display = "grid";
+        badge.style.placeItems = "center";
+        badge.style.zIndex = "2";
 
-      if (typeof sortOrder === "number") {
-        const num = document.createElement("div");
-        num.textContent = String(sortOrder);
-        num.style.minWidth = `${BADGE_INNER}px`;
-        num.style.height = `${BADGE_INNER}px`;
-        num.style.borderRadius = `${BADGE_INNER / 2}px`;
-        num.style.background = "#2ca478";
-        num.style.color = "#fff";
-        num.style.fontWeight = "700";
-        num.style.fontSize = "12px";
-        num.style.lineHeight = `${BADGE_INNER}px`;
-        num.style.textAlign = "center";
-        badge.appendChild(num);
-      } else {
         const bag = document.createElement("img");
         bag.src = "/badge-bag.svg";
         bag.alt = "プランに含まれる";
         bag.style.width = "14px";
         bag.style.height = "14px";
         badge.appendChild(bag);
-      }
 
-      container.appendChild(badge);
+        container.appendChild(badge);
+      }
     }
 
     const marker = new AdvancedMarkerElement({
@@ -146,7 +152,7 @@ function CustomMarker({
     return () => {
       if (markerRef.current) markerRef.current.map = null;
     };
-  }, [map, markerLib, position, isFavorite, isSelected, inPlan, sortOrder, onClick]);
+  }, [map, markerLib, position, isFavorite, isSelected, inPlan, sortOrder, forceNumberPin, onClick]);
 
   return null;
 }

--- a/front/src/components/Header.jsx
+++ b/front/src/components/Header.jsx
@@ -5,18 +5,22 @@ function Header() {
   return (
     <header
       style={{
-        backgroundColor: "#eee",
-        padding: "1.5% 4%",
+        height: "var(--header-h)",
+        padding: "0 4%",
         display: "flex",
         alignItems: "center",
         justifyContent: "space-between",
-        gap: "2%"
-      }}>
-      <h1>VloMaPlan</h1>
+        gap: "2%",
+        backgroundColor: "#eee",
+        boxSizing: "border-box",
+        borderBottom: "1px solid #ddd",
+      }}
+    >
+      <h1 style={{ margin: 0 }}>VloMaPlan</h1>
       <SearchBar />
       <UserMenuOrLogout />
     </header>
-  )
+  );
 }
 
 export default Header;

--- a/front/src/components/LoginOverlay.jsx
+++ b/front/src/components/LoginOverlay.jsx
@@ -134,26 +134,6 @@ export default function LoginOverlay({ onClose, onSwitchToRegister }) {
             style={inputStyle}
           />
 
-          <button
-            type="button"
-            onClick={() => {
-              onClose();
-              navigate("/password/forgot");
-            }}
-            style={{
-              border: "none",
-              background: "transparent",
-              color: "#47625a",
-              fontSize: 14,
-              marginTop: 2,
-              marginBottom: 2,
-              textDecoration: "none",
-              cursor: "pointer",
-            }}
-          >
-            パスワードを忘れた場合
-          </button>
-
           <button type="submit" disabled={submitting} style={primaryBtn}>
             {submitting ? "ログイン中…" : "ログイン"}
           </button>

--- a/front/src/components/MapSearchBar.jsx
+++ b/front/src/components/MapSearchBar.jsx
@@ -1,4 +1,6 @@
-function MapSearchBar({ onFocus }) {
+function MapSearchBar({ onPress, onFocus }) {
+  const trigger = onPress || onFocus;
+
   return (
     <div
       style={{
@@ -13,8 +15,12 @@ function MapSearchBar({ onFocus }) {
     >
       <input
         type="text"
-        onFocus={onFocus}
         placeholder="行きたい場所をお気に入りに追加"
+        readOnly
+        onMouseDown={(e) => { e.preventDefault(); trigger?.(); }}
+        onTouchStart={(e) => { e.preventDefault(); trigger?.(); }}
+        onClick={(e) => { e.preventDefault(); trigger?.(); }}
+        onFocus={(e) => { e.target.blur(); trigger?.(); }}
         style={{
           height: "100%",
           width: "100%",
@@ -25,7 +31,6 @@ function MapSearchBar({ onFocus }) {
           border: "1px solid #ccc",
           borderRadius: 8,
         }}
-        readOnly
       />
     </div>
   );

--- a/front/src/components/PlaceAutocomplete.jsx
+++ b/front/src/components/PlaceAutocomplete.jsx
@@ -1,14 +1,17 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useMapsLibrary } from "@vis.gl/react-google-maps";
 import { useAutocompleteSuggestions } from "../hooks/useAutocompleteSuggestions";
 
-function PlaceAutocomplete({ onPlaceSelect, onSearchStart }) {
+function PlaceAutocomplete({ onPlaceSelect, onSearchStart, inputRef: externalRef }) {
   useMapsLibrary("places");
 
   const [inputValue, setInputValue] = useState("");
   const [searchValue, setSearchValue] = useState("");
   const [isComposing, setIsComposing] = useState(false);
   const [firedStart, setFiredStart] = useState(false);
+
+  const internalRef = useRef(null);
+  const inputRef = externalRef || internalRef;
 
   const { suggestions, resetSession } = useAutocompleteSuggestions(searchValue);
 
@@ -53,6 +56,7 @@ function PlaceAutocomplete({ onPlaceSelect, onSearchStart }) {
   return (
     <div style={{ padding: "10px", backgroundColor: "#fff" }}>
       <input
+        ref={inputRef}
         type="text"
         placeholder="行きたい場所をお気に入りに追加"
         value={inputValue}
@@ -76,7 +80,7 @@ function PlaceAutocomplete({ onPlaceSelect, onSearchStart }) {
           borderRadius: "8px",
         }}
       />
-      <ul role="listbox" style={{ listStyle: "none", margin: 0, padding: "0" }}>
+      <ul role="listbox" style={{ listStyle: "none", margin: 0, padding: 0 }}>
         {suggestions.map((s) => {
           const key =
             s.placePrediction?.id ??

--- a/front/src/components/PlaceDetailCard.jsx
+++ b/front/src/components/PlaceDetailCard.jsx
@@ -1,4 +1,3 @@
-// src/components/PlaceDetailCard.jsx
 export default function PlaceDetailCard({
   place,
   thumbnailUrl,
@@ -138,7 +137,6 @@ export default function PlaceDetailCard({
           <span style={{ marginLeft: "auto" }}>▾</span>
         </div>
 
-        {/* お気に入り（行きたい）操作行 */}
         <div
           style={{
             marginTop: 10,
@@ -173,12 +171,11 @@ export default function PlaceDetailCard({
               disabled={isSaving || !onAdd}
               style={linkBtnStyle(!(isSaving || !onAdd))}
             >
-              {isSaving ? "保存中..." : "いきたい場所リストに追加"}
+              {isSaving ? "保存中..." : "行きたい場所リストに追加"}
             </button>
           )}
         </div>
 
-        {/* 旅行プラン操作行 */}
         <div
           style={{
             marginTop: 10,

--- a/front/src/components/PlanPanel.jsx
+++ b/front/src/components/PlanPanel.jsx
@@ -1,0 +1,116 @@
+import PlaceDetailCard from "./PlaceDetailCard";
+import { getPlaceId } from "../utils/place";
+
+export default function PlanPanel({
+  plan,                    // { id, name }
+  items,                   // [{ id: itemId, place, thumbnailUrl?, sort_order? }, ...]
+  loading,
+  bottomOffset = "clamp(24px, 6vh, 64px)",
+  onClose,
+  onSelect,                // (item) => void
+  onRemoveFromPlan,        // async (itemId, placeId) => void
+  planByPlaceId,           // map[pid] = { planId, planName, itemId }
+  variant = "overlay",     // "overlay" | "docked"
+}) {
+  const isDocked = variant === "docked";
+
+  const containerStyle = isDocked
+    ? {
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        background: "#fff",
+        borderRadius: 16,
+        boxShadow: "0 6px 16px rgba(0,0,0,.12)",
+        border: "1px solid #eee",
+        overflow: "hidden",
+      }
+    : {
+        position: "absolute",
+        left: "2.5%",
+        right: "2.5%",
+        bottom: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset})`,
+        background: "#fff",
+        borderRadius: 16,
+        boxShadow: "0 10px 24px rgba(0,0,0,.2)",
+        zIndex: 3000,
+        display: "flex",
+        flexDirection: "column",
+        height: "50vh",
+        overflow: "hidden",
+      };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+      }}
+      style={containerStyle}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: 12,
+          borderBottom: "1px solid #eee",
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 16 }}>
+          {plan?.name ?? "旅行プラン"}
+        </div>
+        <div style={{ marginLeft: "auto", fontSize: 12, color: "#666" }}>
+          {loading ? "読込中…" : `${items.length}件`}
+        </div>
+        <button
+          type="button"
+          aria-label="close"
+          onClick={onClose}
+          style={{
+            marginLeft: 8,
+            background: "#f2f2f2",
+            border: "none",
+            width: 28,
+            height: 28,
+            borderRadius: 14,
+            cursor: "pointer",
+            fontWeight: 700,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: "auto", padding: 12, gap: 10, display: "grid" }}>
+        {items.length === 0 && !loading && (
+          <div style={{ color: "#666" }}>このプランにはまだ場所がありません</div>
+        )}
+
+        {items.map((it) => {
+          const pid = getPlaceId(it.place);
+          const mem =
+            planByPlaceId?.[pid] || { planId: plan.id, planName: plan.name, itemId: it.id };
+          return (
+            <PlaceDetailCard
+              key={it.id}
+              variant="inline"
+              place={it.place}
+              thumbnailUrl={it.thumbnailUrl}
+              isSaved={false}
+              isSaving={false}
+              onAdd={undefined}
+              onRemove={undefined}
+              onAddToPlan={undefined}
+              planMembership={mem}
+              onRemoveFromPlan={() => onRemoveFromPlan?.(it.id, pid)}
+              onRootClick={() => onSelect?.(it)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/PlanPickerModal.jsx
+++ b/front/src/components/PlanPickerModal.jsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { listTravelPlans } from "../api/travel_plans";
+
+export default function PlanPickerModal({ onClose, onSelect }) {
+  const [loading, setLoading] = useState(true);
+  const [plans, setPlans] = useState([]);
+  const [selectedId, setSelectedId] = useState(null);
+  const [error, setError] = useState(null);
+  const firstFocusRef = useRef(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await listTravelPlans({ page: 1, per: 200 });
+        if (!mounted) return;
+        const items = res.items || [];
+        setPlans(items);
+        setSelectedId(items[0]?.id ?? null);
+        setTimeout(() => firstFocusRef.current?.focus(), 0);
+      } catch (e) {
+        if (!mounted) return;
+        setError(e?.message || "読み込みに失敗しました");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false; };
+  }, []);
+
+  const selectedPlan = useMemo(
+    () => plans.find(p => p.id === selectedId) || null,
+    [plans, selectedId]
+  );
+
+  function handleSubmit() {
+    if (!selectedPlan) return;
+    onSelect?.({ id: selectedPlan.id, name: selectedPlan.name });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      onClick={onClose}
+      style={{
+        position: "fixed", inset: 0, background: "rgba(0,0,0,.4)",
+        zIndex: 5000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16,
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: "min(520px, 96vw)", background: "#fff", borderRadius: 16,
+          boxShadow: "0 10px 24px rgba(0,0,0,.25)", padding: 16,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{ fontWeight: 700, fontSize: 18 }}>どの旅行プランを表示しますか？</div>
+          <button
+            type="button"
+            aria-label="close"
+            onClick={onClose}
+            style={{ marginLeft: "auto", background: "#f2f2f2", border: "none",
+              width: 28, height: 28, borderRadius: 14, cursor: "pointer", fontWeight: 700 }}
+          >
+            ×
+          </button>
+        </div>
+
+        {error && <div style={{ marginTop: 10, color: "#d00", fontSize: 13 }}>{error}</div>}
+
+        <div style={{ marginTop: 10 }}>
+          {loading ? (
+            <div style={{ padding: 12, color: "#666" }}>読み込み中…</div>
+          ) : plans.length === 0 ? (
+            <div style={{ padding: 12, color: "#666" }}>プランが見つかりません</div>
+          ) : (
+            <select
+              ref={firstFocusRef}
+              value={selectedId ?? ""}
+              onChange={(e) => setSelectedId(Number(e.target.value))}
+              style={{ width: "100%", border: "1px solid #eee", borderRadius: 10, padding: "10px" }}
+              aria-label="旅行プランの選択"
+            >
+              {plans.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name} {typeof p.itemsCount === "number" ? `（${p.itemsCount}件）` : ""}
+                </option>
+              ))}
+            </select>
+          )}
+        </div>
+
+        <div style={{ marginTop: 14, display: "flex", justifyContent: "flex-end", gap: 8 }}>
+          <button type="button" onClick={onClose} style={{ background: "none", border: "none", color: "#333" }}>
+            キャンセル
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!selectedPlan}
+            style={{
+              background: "#2CA478", color: "#fff",
+              border: "none", padding: "8px 16px", borderRadius: 999,
+              fontWeight: 700, cursor: "pointer"
+            }}
+          >
+            このプランを表示
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/SearchBar.jsx
+++ b/front/src/components/SearchBar.jsx
@@ -1,60 +1,159 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import useIsMobile from "../hooks/useIsMobile";
 
+/**
+ * ヘッダー等で使う汎用検索バー。
+ * ポリシー：
+ * - モバイル：ボタン非表示（キーボードの「検索」キーで送信）
+ * - デスクトップ：送信ボタンを表示（アクセシビリティと発見性のため）
+ * - 送信時は iOS/Android でも確実にキーボードを閉じてから遷移
+ */
 function SearchBar({
   placeholder = "Vlogを検索",
-  autoFocus = false,
-  onBeforeSubmit, // 送信直前に実行したい処理があれば渡す
+  autoFocus = false,      // デフォルト false（ヘッダーからは付けない）
+  onBeforeSubmit,         // 任意：トラッキング等のフック
 }) {
   const [keyword, setKeyword] = useState("");
   const navigate = useNavigate();
   const inputRef = useRef(null);
+  const dummyRef = useRef(null); // 非入力要素に一時フォーカス（KBクローズ保険）
+  const isMobile = useIsMobile(768);
 
-  // モバイルSafari対策も兼ねて、マウント後に明示フォーカス
+  // 必要なときだけ（例：TopQuickStartOverlay）自動フォーカス可
   useEffect(() => {
     if (autoFocus && inputRef.current) {
       setTimeout(() => inputRef.current?.focus(), 0);
     }
   }, [autoFocus]);
 
+  const isIOS =
+    typeof navigator !== "undefined" &&
+    (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
+  const isAndroid =
+    typeof navigator !== "undefined" &&
+    /Android/i.test(navigator.userAgent || "");
+
+  const closeKeyboardHard = () => {
+    const el = inputRef.current;
+    if (!el) return;
+
+    // まず blur
+    el.blur();
+
+    // 非入力要素に一時フォーカス（KBを確実に閉じる）
+    if (dummyRef.current && typeof dummyRef.current.focus === "function") {
+      dummyRef.current.focus();
+    }
+
+    // 一瞬 readonly（再フォーカス抑制：iOS/Android両対応）
+    const prevReadOnly = el.readOnly;
+    el.readOnly = true;
+    setTimeout(() => {
+      el.readOnly = prevReadOnly;
+    }, 0);
+
+    // iOSのビューポートズレ保険
+    if (isIOS) {
+      setTimeout(() => {
+        try { window.scrollTo(0, 0); } catch (_) {}
+      }, 0);
+    }
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
+
     const k = keyword.trim();
     if (!k) return;
 
     if (onBeforeSubmit) {
-      await onBeforeSubmit();
+      try { await onBeforeSubmit(); } catch (_) {}
     }
 
-    const modifiedKeyword = `${k} Vlog`;
-    navigate(`/search?q=${encodeURIComponent(modifiedKeyword)}`);
+    // まず確実にキーボードを閉じる
+    closeKeyboardHard();
+
+    // Androidは少し遅らせると安定
+    const delay = isAndroid ? 50 : 0;
+    setTimeout(() => {
+      const q = `${k} Vlog`;
+      navigate(`/search?q=${encodeURIComponent(q)}`);
+    }, delay);
   };
 
   return (
-    <form onSubmit={handleSubmit} role="search" aria-label="動画検索">
-      <input
-        ref={inputRef}
-        type="text"
-        value={keyword}
-        onChange={(e) => setKeyword(e.target.value)}
-        placeholder={placeholder}
-        autoFocus={autoFocus}
-        aria-label="検索キーワード"
-        style={{
-          width: "100%",
-          maxWidth: "100%",
-          boxSizing: "border-box",
-          padding: "12px 16px",
-          borderRadius: 9999,
-          border: "1px solid #cfd5d9",
-          outline: "none",
-        }}
+    <>
+      {/* キーボードを閉じるための一時フォーカス先（画面には出ない） */}
+      <div
+        ref={dummyRef}
+        tabIndex={-1}
+        aria-hidden="true"
+        style={{ position: "absolute", width: 0, height: 0, overflow: "hidden" }}
       />
-      {/* Enter送信を安定させるために隠しsubmitボタンを置く */}
-      <button type="submit" style={{ display: "none" }}>
-        検索
-      </button>
-    </form>
+      <form
+        onSubmit={handleSubmit}
+        role="search"
+        aria-label="動画検索"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flex: 1,
+          maxWidth: 640,
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="search"
+          inputMode="search"
+          enterKeyHint="search"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder={placeholder}
+          autoFocus={autoFocus} // ← propsを尊重（ヘッダーでは通常false）
+          aria-label="検索キーワード"
+          style={{
+            flex: 1,
+            width: "100%",
+            maxWidth: "100%",
+            boxSizing: "border-box",
+            padding: "12px 16px",
+            borderRadius: 9999,
+            border: "1px solid #cfd5d9",
+            outline: "none",
+          }}
+        />
+
+        {/* デスクトップのみ、明示的な「検索」ボタンを表示 */}
+        {!isMobile && (
+          <button
+            type="submit"
+            aria-label="検索を実行"
+            // onMouseDownでのフォーカス移動は handleSubmit 内の closeKeyboardHard で対策済み
+            style={{
+              flexShrink: 0,
+              padding: "10px 16px",
+              borderRadius: 9999,
+              border: "none",
+              background: "#2CA478",
+              color: "#fff",
+              fontWeight: 700,
+              cursor: "pointer",
+              lineHeight: 1,
+            }}
+          >
+            検索
+          </button>
+        )}
+
+        {/* Enter送信用の隠しボタン（モバイルでの挙動安定用） */}
+        <button type="submit" style={{ display: "none" }}>
+          検索
+        </button>
+      </form>
+    </>
   );
 }
 

--- a/front/src/components/TravelPlanModal.jsx
+++ b/front/src/components/TravelPlanModal.jsx
@@ -15,7 +15,6 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
   const [containsMap, setContainsMap] = useState({});
   const [selectedPlanId, setSelectedPlanId] = useState(null);
 
-  const [query, setQuery] = useState("");
   const [creating, setCreating] = useState(false);
   const [newPlanName, setNewPlanName] = useState("");
   const newNameRef = useRef(null);
@@ -63,12 +62,6 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
     })();
     return () => { mounted = false; };
   }, [placeId]);
-
-  const filteredPlans = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return plans;
-    return plans.filter(p => (p.name || "").toLowerCase().includes(q));
-  }, [plans, query]);
 
   const selectedPlanName = useMemo(() => {
     if (selectedPlanId === NEW_VALUE) return newPlanName.trim();
@@ -189,18 +182,8 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
           追加対象：<b>{place?.name ?? "-"}</b>
         </div>
 
-        <div style={{ marginTop: 12, display: "flex", gap: 8 }}>
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="プラン名で検索"
-            aria-label="プラン検索"
-            style={{ flex: 1, border: "1px solid #ddd", borderRadius: 8, padding: "8px 10px" }}
-          />
-        </div>
-
-        <div style={{ marginTop: 10 }}>
+        {/* 検索欄は撤去してシンプルにセレクトのみ */}
+        <div style={{ marginTop: 12 }}>
           {loading ? (
             <div style={{ padding: 12, color: "#666" }}>読み込み中…</div>
           ) : (
@@ -211,7 +194,7 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
               aria-label="旅行プランの選択"
             >
               <option value={NEW_VALUE}>＋ 新しいプランを作成…</option>
-              {filteredPlans.map((p) => {
+              {plans.map((p) => {
                 const hit = containsMap[p.id];
                 const already = !!hit?.hasPlace;
                 const suffix = already ? "（この場所は追加済み）" : "";
@@ -245,7 +228,7 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
                 padding: "8px 12px", cursor: creating ? "default" : "pointer", opacity: creating ? 0.6 : 1
               }}
             >
-              {creating ? "作成中…" : "作成のみ"}
+              {creating ? "作成中…" : "作成"}
             </button>
           </div>
         )}

--- a/front/src/components/WishlistPanel.jsx
+++ b/front/src/components/WishlistPanel.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef } from "react";
+import PlaceDetailCard from "./PlaceDetailCard";
+import { getPlaceId } from "../utils/place";
+
+export default function WishlistPanel({
+  items,
+  loading,
+  hasNext,
+  onLoadMore,
+  onClose,
+  onSelect,
+  onRemove,
+  onAddToPlan,
+  totalCount,
+  planByPlaceId,
+  onRemoveFromPlan,
+  variant = "docked",
+  bottomOffset = "clamp(24px, 6vh, 64px)",
+  heightPx = 280,
+}) {
+  const sentinelRef = useRef(null);
+
+  useEffect(() => {
+    if (!hasNext || loading) return;
+    const el = sentinelRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) onLoadMore?.();
+      });
+    });
+    io.observe(el);
+    return () => io.disconnect();
+  }, [hasNext, loading, onLoadMore]);
+
+  const isDocked = variant === "docked";
+
+  const containerStyle = isDocked
+    ? {
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        background: "#fff",
+        borderRadius: 16,
+        boxShadow: "0 6px 16px rgba(0,0,0,.12)",
+        border: "1px solid #eee",
+        overflow: "hidden",
+      }
+    : {
+        position: "absolute",
+        left: "2.5%",
+        right: "2.5%",
+        bottom: `calc(env(safe-area-inset-bottom, 0px) + ${bottomOffset})`,
+        background: "#fff",
+        borderRadius: 16,
+        boxShadow: "0 10px 24px rgba(0,0,0,.2)",
+        zIndex: 3000,
+        display: "flex",
+        flexDirection: "column",
+        height: heightPx ? heightPx : "50vh",
+        overflow: "hidden",
+      };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") e.stopPropagation();
+      }}
+      style={containerStyle}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          padding: 12,
+          borderBottom: "1px solid #eee",
+        }}
+      >
+        <div style={{ fontWeight: 700, fontSize: 16 }}>行きたい場所リスト</div>
+        <div style={{ marginLeft: "auto", fontSize: 12, color: "#666" }}>
+          {(Number.isFinite(totalCount) ? totalCount : items.length)}件
+          {loading ? "(読込中)" : ""}
+        </div>
+        <button
+          type="button"
+          aria-label="close"
+          onClick={onClose}
+          style={{
+            marginLeft: 8,
+            background: "#f2f2f2",
+            border: "none",
+            width: 28,
+            height: 28,
+            borderRadius: 14,
+            cursor: "pointer",
+            fontWeight: 700,
+          }}
+        >
+          ×
+        </button>
+      </div>
+
+      <div style={{ flex: 1, overflowY: "auto", padding: 12, gap: 10, display: "grid" }}>
+        {items.length === 0 && !loading && <div style={{ color: "#666" }}>まだ保存がありません</div>}
+
+        {items.map((it) => {
+          const pid = getPlaceId(it.place);
+          return (
+            <PlaceDetailCard
+              key={it.id}
+              variant="inline"
+              place={it.place}
+              thumbnailUrl={it.thumbnailUrl}
+              isSaved
+              isSaving={false}
+              onRemove={() => onRemove?.(it.id)}
+              onAddToPlan={() => onAddToPlan?.(it)}
+              planMembership={planByPlaceId?.[pid]}
+              onRemoveFromPlan={() => onRemoveFromPlan?.(pid)}
+              onRootClick={() => onSelect?.(it)}
+            />
+          );
+        })}
+
+        <div ref={sentinelRef} style={{ height: 1 }} />
+        {loading && (
+          <div style={{ padding: "8px 0", textAlign: "center", color: "#666" }}>読み込み中…</div>
+        )}
+        {!hasNext && items.length > 0 && (
+          <div style={{ padding: "6px 0", textAlign: "center", color: "#999", fontSize: 12 }}>
+            以上です
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/layouts/DesktopLayout.jsx
+++ b/front/src/components/layouts/DesktopLayout.jsx
@@ -34,13 +34,22 @@ function DesktopLayout({ id, relatedVideos, channels, currentVideo }) {
         minHeight: 0,
       }}
     >
-      <section style={{ minWidth: 0, minHeight: 0, display: "flex", flexDirection: "column" }}>
+      <section
+        style={{
+          minWidth: 0,
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+          overflow: "hidden",
+        }}
+      >
         <div style={{ width: "100%", aspectRatio: "16/9" }}>
           <VideoPlayerWrapper videoId={id} />
         </div>
 
         <h3 style={{ marginTop: "1rem" }}>関連動画</h3>
-        <div style={{ flex: 1, overflowY: "auto", minHeight: 0 }}>
+
+        <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
           {relatedVideos.map((video) => (
             <VideoItem
               key={video.id}
@@ -62,9 +71,7 @@ function DesktopLayout({ id, relatedVideos, channels, currentVideo }) {
           }}
         >
           <div>
-            <PlaceAutocomplete
-              onPlaceSelect={handleSelectPlace}
-            />
+            <PlaceAutocomplete onPlaceSelect={handleSelectPlace} />
           </div>
 
           <div style={{ position: "relative", minHeight: 0 }}>
@@ -77,6 +84,7 @@ function DesktopLayout({ id, relatedVideos, channels, currentVideo }) {
                 onSelectPlace={handleSelectPlace}
                 onWishlistTotalChange={setWishlistTotal}
               />
+
               <div
                 aria-hidden
                 style={{

--- a/front/src/components/layouts/MainLayout.jsx
+++ b/front/src/components/layouts/MainLayout.jsx
@@ -4,11 +4,20 @@ import Header from "../Header";
 
 function MainLayout() {
   return (
-      <>
-        <Header />
+    <div
+      style={{
+        minHeight: "100dvh",
+        display: "grid",
+        gridTemplateRows: "auto 1fr",
+        minWidth: 0,
+      }}
+    >
+      <Header />
+      <div style={{ minHeight: 0 }}>
         <ScrollToTop />
         <Outlet />
-      </>
+      </div>
+    </div>
   );
 }
 

--- a/front/src/hooks/useBlurOnRouteChange.js
+++ b/front/src/hooks/useBlurOnRouteChange.js
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function useBlurOnRouteChange() {
+  const loc = useLocation();
+  useEffect(() => {
+    const el = document.activeElement;
+    if (el && typeof el.blur === "function") {
+      el.blur();
+    }
+  }, [loc.pathname, loc.search, loc.hash]);
+}

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -1,39 +1,41 @@
 :root {
+  --page-pad-inline: clamp(12px, 4vw, 32px);
+  --header-h: 64px;
+  --bottom-bar-h: 40px;
+
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
   color-scheme: light;
   color: #111;
   background-color: #fff;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
+html, body, #root {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+}
+
+body {
+  min-width: 320px;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+
 a {
   font-weight: 500;
   color: #646cff;
   text-decoration: inherit;
 }
-a:hover {
-  color: #535bf2;
-}
+a:hover { color: #535bf2; }
 
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 1em;
-  line-height: 1.1;
-}
+h1 { font-size: 1em; line-height: 1.1; }
 
 button {
   border-radius: 8px;
@@ -46,25 +48,21 @@ button {
   cursor: pointer;
   transition: border-color 0.25s;
 }
-button:hover {
-  border-color: #646cff;
-}
-button:focus {
-  outline: none;
-}
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
+button:hover { border-color: #646cff; }
+button:focus { outline: none; }
+button:focus-visible { outline: 4px auto -webkit-focus-ring-color; }
 
 @media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+  :root { color: #213547; background-color: #ffffff; }
+  a:hover { color: #747bff; }
+  button { background-color: #f9f9f9; }
+}
+
+.full-bleed { padding-inline: 0 !important; }
+.centered { display: grid; place-items: center; text-align: center; }
+
+.container {
+  max-width: 1200px;
+  margin-inline: auto;
+  padding-inline: var(--page-pad-inline);
 }

--- a/front/src/utils/fetchYoutubeVideos.js
+++ b/front/src/utils/fetchYoutubeVideos.js
@@ -1,62 +1,104 @@
+// fetchYoutubeVideos.js
 const fetchYoutubeVideos = async (keyword) => {
   const API_KEY = import.meta.env.VITE_YOUTUBE_API_KEY;
 
-  const searchRes = await fetch(
-    `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${encodeURIComponent(keyword)}&type=video&maxResults=50&key=${API_KEY}`
-  );
+  // 1) 検索段階でできるだけ除外（ただし完全ではないので後段で二重チェック）
+  const searchURL = new URL("https://www.googleapis.com/youtube/v3/search");
+  searchURL.searchParams.set("part", "snippet");
+  searchURL.searchParams.set("q", keyword);
+  searchURL.searchParams.set("type", "video");
+  searchURL.searchParams.set("maxResults", "50");
+  searchURL.searchParams.set("key", API_KEY);
+  searchURL.searchParams.set("safeSearch", "strict");        // ← 年齢制限/アダルト寄りを検索から除外
+  searchURL.searchParams.set("videoEmbeddable", "true");     // ← 埋め込み可能な動画のみ
+  searchURL.searchParams.set("videoSyndicated", "true");     // ← 外部サイト再生可のみ（保険）
 
+  const searchRes = await fetch(searchURL.toString());
   const searchData = await searchRes.json();
 
-  const videoIds = searchData.items.map((item) => item.id.videoId).join(",");
-  const channelIds = [...new Set(searchData.items.map((item) => item.snippet.channelId))].join(",");
+  const items = Array.isArray(searchData?.items) ? searchData.items : [];
+  if (items.length === 0) {
+    return { videos: [], channels: [] };
+  }
 
-  const videoDetailsRes = await fetch(
-    `https://www.googleapis.com/youtube/v3/videos?part=snippet,statistics,contentDetails,status&id=${videoIds}&key=${API_KEY}`
-  );
+  const videoIds = items.map((item) => item?.id?.videoId).filter(Boolean);
+  const channelIdSet = new Set(items.map((item) => item?.snippet?.channelId).filter(Boolean));
+
+  // videoIds が空ならここで終了
+  if (videoIds.length === 0) {
+    return { videos: [], channels: [] };
+  }
+
+  // 2) 詳細取得（ここで age restriction を厳密チェック）
+  const videosURL = new URL("https://www.googleapis.com/youtube/v3/videos");
+  videosURL.searchParams.set("part", "snippet,statistics,contentDetails,status");
+  videosURL.searchParams.set("id", videoIds.join(","));
+  videosURL.searchParams.set("key", API_KEY);
+
+  const videoDetailsRes = await fetch(videosURL.toString());
   const videoDetails = await videoDetailsRes.json();
+  const videoItems = Array.isArray(videoDetails?.items) ? videoDetails.items : [];
 
+  // ISO 8601 PTxxMxS → 秒
   const durationToSeconds = (duration) => {
-    const match = duration.match(/PT(?:(\d+)M)?(?:(\d+)S)?/);
+    const match = duration?.match(/PT(?:(\d+)M)?(?:(\d+)S)?/);
     const minutes = parseInt(match?.[1] || "0", 10);
     const seconds = parseInt(match?.[2] || "0", 10);
     return minutes * 60 + seconds;
-  }
+  };
 
-  const filteredVideos = videoDetails.items
-    .filter((video) => {
-      const durationSec = durationToSeconds(video.contentDetails?.duration || "");
-      const embeddable = video.status?.embeddable;
-      return durationSec > 180 && embeddable;
+  // age-restricted 判定（contentDetails.contentRating.ytRating === 'ytAgeRestricted'）
+  const isAgeRestricted = (v) =>
+    v?.contentDetails?.contentRating?.ytRating === "ytAgeRestricted";
+
+  // フィルタリング：
+  // - 3分超
+  // - 埋め込み可能
+  // - 年齢制限なし
+  const filteredVideos = videoItems
+    .filter((v) => {
+      const durationSec = durationToSeconds(v?.contentDetails?.duration || "");
+      const embeddable = v?.status?.embeddable === true;
+      return durationSec > 180 && embeddable && !isAgeRestricted(v);
     })
-    .map((video) => ({
-      id: video.id,
-      title: video.snippet.title,
+    .map((v) => ({
+      id: v.id,
+      title: v.snippet.title,
       thumbnail:
-        ( video.snippet.thumbnails.maxres?.url ??
-          video.snippet.thumbnails.standard?.url ??
-          video.snippet.thumbnails.high?.url ??
-          video.snippet.thumbnails.medium?.url ??
-          `https://i.ytimg.com/vi/${video.id}/hq720.jpg`),
-      channelId: video.snippet.channelId,
-      duration: video.contentDetails.duration,
-      viewCount: video.statistics.viewCount,
-    }))
+        v.snippet.thumbnails?.maxres?.url ??
+        v.snippet.thumbnails?.standard?.url ??
+        v.snippet.thumbnails?.high?.url ??
+        v.snippet.thumbnails?.medium?.url ??
+        `https://i.ytimg.com/vi/${v.id}/hq720.jpg`,
+      channelId: v.snippet.channelId,
+      duration: v.contentDetails.duration,
+      viewCount: v.statistics?.viewCount ?? "0",
+    }));
 
-  const channelDetailsRes = await fetch(
-    `https://www.googleapis.com/youtube/v3/channels?part=snippet,statistics&id=${channelIds}&key=${API_KEY}`
-  );
-  const channelDetails = await channelDetailsRes.json();
+  // チャンネル情報（存在するときだけ問い合わせ）
+  const channelIds = Array.from(channelIdSet);
+  let channels = [];
+  if (channelIds.length > 0) {
+    const channelsURL = new URL("https://www.googleapis.com/youtube/v3/channels");
+    channelsURL.searchParams.set("part", "snippet,statistics");
+    channelsURL.searchParams.set("id", channelIds.join(","));
+    channelsURL.searchParams.set("key", API_KEY);
 
-  const channels = channelDetails.items.map((channel) => ({
-    id: channel.id,
-    title: channel.snippet.title,
-    icon: channel.snippet.thumbnails.default.url,
-  }))
+    const channelDetailsRes = await fetch(channelsURL.toString());
+    const channelDetails = await channelDetailsRes.json();
+    const channelItems = Array.isArray(channelDetails?.items) ? channelDetails.items : [];
+
+    channels = channelItems.map((ch) => ({
+      id: ch.id,
+      title: ch.snippet.title,
+      icon: ch.snippet.thumbnails?.default?.url ?? "",
+    }));
+  }
 
   return {
     videos: filteredVideos,
     channels,
-  }
-}
+  };
+};
 
 export default fetchYoutubeVideos;


### PR DESCRIPTION
## 概要
**旅行プランのUI**（プラン選択モーダル、ドック型パネル、番号ピン表示）を実装。  
**デスクトップの高さ/スクロール問題の修正**、**検索バー・モバイルシートのUX改善**、**YouTube検索方法を修正**。


## 変更内容（ハイライト）
- **旅行プランUI**
  - `PlanPickerModal` でプラン選択 → `PlanPanel` を**ドック表示**して一覧管理
  - マップに**番号ピン**を表示（並び順を視覚化）  
    - `CustomMarker` に `forceNumberPin` 追加
  - Wishlist/Plan への追加・削除時に **membership/cache** を同期更新

- **レイアウト/スクロール修正（デスクトップ）**
  - `MainLayout`: `gridTemplateRows: auto 1fr` で Header 固定 + 下段が**ビューポート高**にフィット
  - `DesktopLayout`: 左カラムは「関連動画のみ**スクロール**」、右カラムは検索バー + マップを**固定比率でフィット**
  - `MapPreview` を**グリッド化**、ドックパネル（Wishlist/Plan）との併用で安定表示

- **モバイルUX**
  - 画面下部の `MapSearchBar` をタップ → **シート開く & オートコンプリートに自動フォーカス**
  - シートの snap/高さ調整、`body.style.overflow` の扱い簡素化

- **検索バーUX**
  - `SearchBar`: 送信時に**確実にキーボードを閉じる**（iOS/Android対応）
  - デスクトップでは**明示的な「検索」ボタン**を表示

- **YouTube 取得の安全性/堅牢性**
  - `safeSearch=strict`, `videoEmbeddable=true`, `videoSyndicated=true`
  - 年齢制限（`ytAgeRestricted`）でサイト内で閲覧不可能な動画の除外
  - URL生成/レスポンス処理を堅牢化

- **スタイル/その他**
  - `--header-h` を導入、Header高さを統一管理
  - `html, body, #root { height:100%; }` を設定
  - `body` の `display:flex; place-items:center;` を削除（レイアウト破壊の原因）

## 変更ファイルの主なポイント
- `components/layouts/MainLayout.jsx`
  - Header固定 + 下段 1fr、`minHeight:0` で高さ伝播
- `components/layouts/DesktopLayout.jsx`
  - 左：動画固定＋**関連のみスクロール** / 右：検索バー＋マップ
- `components/MapPreview.jsx`
  - グリッド化、ドック型パネル（Wishlist/Plan）/ PlanPicker 連携、番号ピン表示、各種イベント同期
- `components/CustomMarker.jsx`
  - `forceNumberPin` で数字ピン描画
- `components/Header.jsx` / `index.css`
  - `--header-h`反映、リセットCSSの整理
- `components/SearchBar.jsx`
  - モバイルのハードキーボードクローズ / デスクトップボタン
- `components/layouts/MobileLayout.jsx` / `MapSearchBar.jsx` / `PlaceAutocomplete.jsx`
  - シート起動→入力フォーカス、`onPress`ハンドラ導入、`inputRef` 受け取り
- `utils/fetchYoutubeVideos.js`
  - フィルタ強化、URL構築の堅牢化
- その他：軽微な文言/不要要素の削除

## 動作確認
### デスクトップ
- Header固定。ページ本体は**ヘッダーを除いた高さ**でフィット
- 左カラム：動画は固定、**関連動画リストのみスクロール**可能
- 右カラム：検索バー + マップ。マップは**現在のビューポート高**にフィット
- ハート → **行きたいリストのドックパネル**開閉・無限ロード
- スーツケース → **プラン選択→ドックパネル**表示、マップは**番号ピン**表示
- パネル内削除時、ピン/メンバーシップの状態が同期更新される

### モバイル
- 下部の検索バータップ → **シート展開** & オートコンプリートに**自動フォーカス**
- シート snap / キーボード閉じ動作 の安定性

### YouTube 検索
- 3分以下 (ショート動画)/ 非埋め込み / 年齢制限の動画が結果から除外されること