### PR TITLE
Enable plan item DnD, allow wishlist add without video, unify PlaceDetailCard UI, and refactor markers

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -8,6 +8,9 @@
       "name": "front",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/modifiers": "^9.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@vis.gl/react-google-maps": "^1.5.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -327,6 +330,73 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/modifiers": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
+      "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -5501,8 +5571,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/twitch-video-element": {
       "version": "0.1.2",

--- a/front/package.json
+++ b/front/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@vis.gl/react-google-maps": "^1.5.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/front/src/api/wishlists.js
+++ b/front/src/api/wishlists.js
@@ -24,3 +24,10 @@ export async function deleteWishlist(id) {
   if (!res.ok && res.status !== 204) throw new Error(`deleteWishlist failed: ${res.status}`);
   return null;
 }
+
+export async function createWishlist({ place }) {
+  return apiFetchJson(`${base}/api/wishlists`, {
+    method: "POST",
+    body: { place },
+  });
+}


### PR DESCRIPTION
## 概要
- 旅行プラン内アイテムのドラッグ＆ドロップ（DnD）並べ替えを実装し、サーバーへ `sort_order` を永続化。
- 動画なしでも「行きたい場所リスト」に追加できるように API / フロント両方とも変更。
- PlaceDetailCard の表示を統一し、旅行プラン内でもお気に入り（行きたい場所）UIが正しく動くように修正。
- Google Maps のマーカー描画を最適化し、番号ピンや選択状態の描画が安定するように変更。

## 変更内容
### フロントエンド
- `PlanPanel.jsx`
  - @dnd-kit を利用した DnD 並べ替えを追加（`SortableContext` / `useSortable`）。
  - 並べ替え結果を `reorderPlanItems` で PATCH 送信。
  - `PlaceDetailCard` を「お気に入り UI 有効」（`isSaved`, `onAdd`, `onRemove`）で利用可能に。
  - 「並べ替える/完了」トグルボタン、行番号バッジの表示を追加。
- `MapPreview.jsx`
  - 動画が無くても「行きたい場所リストに追加」できるように `createWishlist` を追加し分岐。
  - プラン閲覧時（`PlanPanel`）にもお気に入り追加/削除を渡せるよう props を拡張（`wishlistByPlaceId`, `onAddWishlist`, `onRemoveWishlist`）。
  - `normalizeWithLocalOrder` と `renumber` で並びの安定化。
  - `confirmDisabled` 条件から `currentVideo?.id` を外し、「場所情報のみ」で追加可能に。
- `CustomMarker.jsx`
  - `AdvancedMarkerElement` のインスタンスを再利用するように変更（パフォーマンス/安定性向上）。
  - 番号ピン（`forceNumberPin + sortOrder`）の描画と、お気に入り/プランバッジの同時表示に対応。
  - `zIndex` と `content` の更新処理を整理。
- 依存関係
  - `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/modifiers` を追加。

### サーバーサイド
- `Api::WishlistsController#create`
  - `place_id`/`placeId` の双方を受け取り、`Place` を find_or_create。
  - `Wishlist` を `user + place` で find_or_create（冪等）。
  - サムネイルは最新の `video_view_places` から取得。
- `Api::TravelPlanItemsController#destroy`
  - 削除アイテム以降の `sort_order` を `-1` して詰め直し、`@plan.touch` で更新。
- Strong params ヘルパ `place_params` を追加（`place_id`/`placeId` 両対応）。

## 動作確認
- プラン詳細（docked/overlay）でアイテムを DnD 並べ替え → 順番が即時UI反映され、リロード後も順序が保持される
- プラン内 `PlaceDetailCard` から「行きたい場所に追加/削除」できる（状態表示が切り替わる）
- `TravelPlanItems#destroy` 後に並びの穴が空かない（次要素から `sort_order` が詰まる）
- CustomMarker：番号ピン表示、選択状態の zIndex、プラン/お気に入りバッジの同時表示が崩れない
