### PR TITLE
Feature/mypage UI redesign

### DIFF
--- a/front/src/api/travel_plans.js
+++ b/front/src/api/travel_plans.js
@@ -46,3 +46,13 @@ export async function reorderPlanItems({ planId, items }) {
     body: { items },
   });
 }
+
+export async function deleteTravelPlan({ planId }) {
+  const res = await apiFetch(`${base}/api/travel_plans/${planId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`deleteTravelPlan failed: ${res.status}`);
+  }
+  return null;
+}

--- a/front/src/components/PlanPanel.jsx
+++ b/front/src/components/PlanPanel.jsx
@@ -31,6 +31,7 @@ export default function PlanPanel({
   onRemoveWishlist,
   variant = "overlay",
   onItemsReordered,
+  onDeletePlan,
 }) {
   const isDocked = variant === "docked";
   const [isSorting, setIsSorting] = useState(false);
@@ -70,7 +71,8 @@ export default function PlanPanel({
       };
 
   function SortableRow({ id, index, children }) {
-    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+      useSortable({ id });
     const style = {
       transform: CSS.Transform.toString(transform),
       transition,
@@ -85,7 +87,11 @@ export default function PlanPanel({
       padding: 2,
     };
     return (
-      <div ref={setNodeRef} style={style} {...(isSorting ? { ...attributes, ...listeners } : {})}>
+      <div
+        ref={setNodeRef}
+        style={style}
+        {...(isSorting ? { ...attributes, ...listeners } : {})}
+      >
         <div
           aria-hidden
           style={{
@@ -159,9 +165,7 @@ export default function PlanPanel({
           borderBottom: "1px solid #eee",
         }}
       >
-        <div style={{ fontWeight: 700, fontSize: 16 }}>
-          {plan?.name ?? "旅行プラン"}
-        </div>
+        <div style={{ fontWeight: 700, fontSize: 16 }}>{plan?.name ?? "旅行プラン"}</div>
         <div style={{ marginLeft: "auto", fontSize: 12, color: "#666" }}>
           {loading ? "読込中…" : `${ordered.length}件`}
         </div>
@@ -201,20 +205,28 @@ export default function PlanPanel({
         </button>
       </div>
 
-      <div style={{ flex: 1, overflowY: "auto", padding: 12, gap: 10, display: "grid" }}>
-        {(ordered.length === 0) && !loading && (
+      {/* 本文（スクロール領域） */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: 12,
+          gap: 10,
+          display: "grid",
+          alignContent: "start",
+        }}
+      >
+        {ordered.length === 0 && !loading && (
           <div style={{ color: "#666" }}>このプランにはまだ場所がありません</div>
         )}
 
         {isSorting ? (
           <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-            <SortableContext
-              items={ordered.map((x) => x.id)}
-              strategy={verticalListSortingStrategy}
-            >
+            <SortableContext items={ordered.map((x) => x.id)} strategy={verticalListSortingStrategy}>
               {ordered.map((it, idx) => {
                 const pid = getPlaceId(it.place);
-                const mem = planByPlaceId?.[pid] || { planId: plan.id, planName: plan.name, itemId: it.id };
+                const mem =
+                  planByPlaceId?.[pid] || { planId: plan.id, planName: plan.name, itemId: it.id };
                 const wishlistId = wishlistByPlaceId?.[pid];
                 return (
                   <SortableRow key={it.id} id={it.id} index={idx}>
@@ -239,15 +251,19 @@ export default function PlanPanel({
         ) : (
           ordered.map((it, idx) => {
             const pid = getPlaceId(it.place);
-            const mem = planByPlaceId?.[pid] || { planId: plan.id, planName: plan.name, itemId: it.id };
+            const mem =
+              planByPlaceId?.[pid] || { planId: plan.id, planName: plan.name, itemId: it.id };
             const wishlistId = wishlistByPlaceId?.[pid];
             return (
-              <div key={it.id} style={{
-                display: "grid",
-                gridTemplateColumns: "28px 1fr",
-                alignItems: "start",
-                gap: 8,
-              }}>
+              <div
+                key={it.id}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "28px 1fr",
+                  alignItems: "start",
+                  gap: 8,
+                }}
+              >
                 <div
                   aria-hidden
                   style={{
@@ -283,6 +299,35 @@ export default function PlanPanel({
               </div>
             );
           })
+        )}
+
+        {!!plan?.id && (
+          <>
+            <hr style={{ border: 0, borderTop: "1px solid #eee", margin: "6px 0 12px" }} />
+            <div style={{ display: "flex", justifyContent: "center" }}>
+              <button
+                type="button"
+                onClick={() => {
+                  const ok = window.confirm(
+                    `「${plan.name}」を削除します。よろしいですか？（元に戻せません）`
+                  );
+                  if (!ok) return;
+                  onDeletePlan?.(plan);
+                }}
+                style={{
+                  padding: "10px 14px",
+                  borderRadius: 10,
+                  border: "1px solid #c62828",
+                  background: "#fff",
+                  color: "#c62828",
+                  fontWeight: 700,
+                  cursor: "pointer",
+                }}
+              >
+                このプランを削除する
+              </button>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/front/src/components/SearchBar.jsx
+++ b/front/src/components/SearchBar.jsx
@@ -2,25 +2,17 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import useIsMobile from "../hooks/useIsMobile";
 
-/**
- * ヘッダー等で使う汎用検索バー。
- * ポリシー：
- * - モバイル：ボタン非表示（キーボードの「検索」キーで送信）
- * - デスクトップ：送信ボタンを表示（アクセシビリティと発見性のため）
- * - 送信時は iOS/Android でも確実にキーボードを閉じてから遷移
- */
 function SearchBar({
   placeholder = "Vlogを検索",
-  autoFocus = false,      // デフォルト false（ヘッダーからは付けない）
-  onBeforeSubmit,         // 任意：トラッキング等のフック
+  autoFocus = false,
+  onBeforeSubmit,
 }) {
   const [keyword, setKeyword] = useState("");
   const navigate = useNavigate();
   const inputRef = useRef(null);
-  const dummyRef = useRef(null); // 非入力要素に一時フォーカス（KBクローズ保険）
+  const dummyRef = useRef(null);
   const isMobile = useIsMobile(768);
 
-  // 必要なときだけ（例：TopQuickStartOverlay）自動フォーカス可
   useEffect(() => {
     if (autoFocus && inputRef.current) {
       setTimeout(() => inputRef.current?.focus(), 0);
@@ -39,22 +31,18 @@ function SearchBar({
     const el = inputRef.current;
     if (!el) return;
 
-    // まず blur
     el.blur();
 
-    // 非入力要素に一時フォーカス（KBを確実に閉じる）
     if (dummyRef.current && typeof dummyRef.current.focus === "function") {
       dummyRef.current.focus();
     }
 
-    // 一瞬 readonly（再フォーカス抑制：iOS/Android両対応）
     const prevReadOnly = el.readOnly;
     el.readOnly = true;
     setTimeout(() => {
       el.readOnly = prevReadOnly;
     }, 0);
 
-    // iOSのビューポートズレ保険
     if (isIOS) {
       setTimeout(() => {
         try { window.scrollTo(0, 0); } catch (_) {}
@@ -72,10 +60,8 @@ function SearchBar({
       try { await onBeforeSubmit(); } catch (_) {}
     }
 
-    // まず確実にキーボードを閉じる
     closeKeyboardHard();
 
-    // Androidは少し遅らせると安定
     const delay = isAndroid ? 50 : 0;
     setTimeout(() => {
       const q = `${k} Vlog`;
@@ -85,7 +71,6 @@ function SearchBar({
 
   return (
     <>
-      {/* キーボードを閉じるための一時フォーカス先（画面には出ない） */}
       <div
         ref={dummyRef}
         tabIndex={-1}
@@ -112,7 +97,7 @@ function SearchBar({
           value={keyword}
           onChange={(e) => setKeyword(e.target.value)}
           placeholder={placeholder}
-          autoFocus={autoFocus} // ← propsを尊重（ヘッダーでは通常false）
+          autoFocus={autoFocus}
           aria-label="検索キーワード"
           style={{
             flex: 1,
@@ -126,12 +111,10 @@ function SearchBar({
           }}
         />
 
-        {/* デスクトップのみ、明示的な「検索」ボタンを表示 */}
         {!isMobile && (
           <button
             type="submit"
             aria-label="検索を実行"
-            // onMouseDownでのフォーカス移動は handleSubmit 内の closeKeyboardHard で対策済み
             style={{
               flexShrink: 0,
               padding: "10px 16px",
@@ -148,7 +131,6 @@ function SearchBar({
           </button>
         )}
 
-        {/* Enter送信用の隠しボタン（モバイルでの挙動安定用） */}
         <button type="submit" style={{ display: "none" }}>
           検索
         </button>

--- a/front/src/pages/MyPage.jsx
+++ b/front/src/pages/MyPage.jsx
@@ -1,36 +1,94 @@
-import { useEffect } from "react";
+import { useEffect, useCallback, useState } from "react";
+import { APIProvider } from "@vis.gl/react-google-maps";
 import { fetchIdentity } from "../api/identity";
+import MapPreview from "../components/MapPreview";
+import SearchBar from "../components/SearchBar";
 
 export default function MyPage() {
-
   useEffect(() => {
     fetchIdentity().catch(() => {});
   }, []);
 
-  const cardStyle = {
-    width: "min(560px, 92vw)",
-    borderRadius: 16,
-    background: "rgba(255,255,255,0.94)",
-    boxShadow: "0 10px 30px rgba(0,0,0,0.2)",
-    padding: 20,
-  };
+  const [position, setPosition] = useState({ lat: 35.681236, lng: 139.767125 });
+  const [placeName, setPlaceName] = useState("");
+  const [selectedPlace, setSelectedPlace] = useState(null);
+  const [wishlistTotal, setWishlistTotal] = useState(null);
+  const masked = (wishlistTotal === 0 || wishlistTotal === null) && !selectedPlace;
+
+  const handleSelectPlace = useCallback((p) => {
+    const lat = Number(p.latitude);
+    const lng = Number(p.longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return;
+    setSelectedPlace(p);
+    setPlaceName(p.name || "選択した場所");
+    setPosition({ lat, lng });
+  }, []);
 
   return (
     <div
       style={{
-        minHeight: "100dvh",
+        minHeight: "calc(100dvh - var(--header-h, 0px))",
         display: "grid",
-        placeItems: "start center",
-        paddingTop: 80,
-        background: "linear-gradient(#3b5f56 0 0)",
+        gridTemplateRows: "auto 1fr",
+        gap: 0,
+        padding: 0,
+        minWidth: 0,
       }}
     >
-      <div style={cardStyle}>
-        <h2 style={{ marginTop: 0, marginBottom: 12 }}>マイページ（仮）</h2>
-        <p style={{ marginBottom: 16 }}>
-          ここに検索バー・地図を配置予定
-        </p>
+      <div style={{ maxWidth: 1100, margin: "0 auto", width: "100%", padding: "12px 16px" }}>
+        <SearchBar placeholder="Vlogを探す" />
       </div>
+
+      <APIProvider
+        apiKey={import.meta.env.VITE_GOOGLE_MAPS_API_KEY}
+        libraries={["places"]}
+        language="ja"
+        region="JP"
+      >
+        <div style={{ position: "relative", minHeight: 0, height: "100%" }}>
+          <div style={{ position: "absolute", inset: 0 }}>
+            <MapPreview
+              position={position}
+              placeName={placeName}
+              selectedPlace={selectedPlace}
+              onSelectPlace={handleSelectPlace}
+              onWishlistTotalChange={setWishlistTotal}
+            />
+
+            {/* 初期マスク */}
+            <div
+              aria-hidden
+              style={{
+                position: "absolute",
+                inset: 0,
+                background: "rgba(0,0,0,0.35)",
+                backdropFilter: "blur(1px)",
+                transition: "opacity .25s ease",
+                opacity: masked ? 1 : 0,
+                pointerEvents: masked ? "auto" : "none",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#444",
+                fontSize: 14,
+                fontWeight: "bold",
+                zIndex: 2,
+              }}
+            >
+              <div
+                style={{
+                  padding: "8px 12px",
+                  background: "#fff",
+                  borderRadius: 8,
+                  border: "1px solid rgba(255,255,255,0.2)",
+                }}
+              >
+                ↑ 上の検索バーでVlogを検索するか、右上から「行きたい場所リスト／旅行プラン」を開いてください
+              </div>
+            </div>
+          </div>
+        </div>
+      </APIProvider>
     </div>
   );
 }

--- a/front/src/pages/SearchResultPage.jsx
+++ b/front/src/pages/SearchResultPage.jsx
@@ -33,7 +33,7 @@ function SearchResultPage() {
 
   return (
     <div>
-      <h2>検索結果：{query}</h2>
+      <h3 style={{textAlign: "center"}}>{query}</h3>
       <div>
         {videos.map((video) => (
           <VideoItem


### PR DESCRIPTION
## 概要
マイページを実装し、ヘッダー直下に **SearchBar** を配置した全幅レイアウトの地図ページを作成。
加えて、**旅行プランの削除機能**を `PlanPanel` から実行できるようにし、削除後に地図ピンやメンバーシップ状態が即時に反映されるよう調整。

## 変更内容
- **MyPage**
  - `SearchBar` を導入し、`/search?q=...` へ遷移するように変更
  - `@vis.gl/react-google-maps` の `APIProvider` でマップをラップ
  - ヘッダー＋検索バー＋マップが画面幅・高さいっぱいになるようグリッドを最適化
  - 初期ガイダンスのマスクを追加（検索 or 右上メニュー操作で解除）
- **MapPreview / PlanPanel**
  - `deleteTravelPlan(planId)` API を追加（`DELETE /api/travel_plans/:id`、200/204想定）
  - `PlanPanel` 下部に「このプランを削除する」ボタンを追加し、確認ダイアログ経由で削除
  - 削除成功時に以下を同期更新：
    - `showPlanPanel` を閉じ、`viewPlan` / `viewPlanItems` をクリア
    - `planPins` から該当ピンを除去
    - `planByPlaceId` から該当プランの membership を除去
    - 選択中の場所がプラン所属なら `planMembership` をクリア
    - プラン件数を再取得して右上ボタンの有無/バッジ表示を更新
  - 並べ替え（D&D）中のスタイルとスクロール領域の見直し
- **Search**
  - 検索結果ページのクエリ見出しを中央寄せに変更（`<h3 style={{ textAlign: "center" }}>`）
- **その他**
  - 不要コメント/余白の整理、スタイルの微調整

## 動作確認
1. **マイページ表示**
   - ヘッダー下に検索バー、その下に全幅・全高の地図が表示されること
   - 初期マスクが表示され、検索または右上「行きたい場所リスト／旅行プラン」操作で解除されること
2. **検索バー**
   - 任意キーワードで Enter/検索ボタン → `/search?q=...` に遷移し、検索結果ページでクエリ見出しが中央寄せ表示されること
3. **プラン削除**
   - `PlanPanel` を開く → 最下部「このプランを削除する」→ 確認ダイアログで「はい」
   - 期待挙動：
     - API 成功後、`PlanPanel` が閉じる
     - 地図の当該プラン由来ピンが消える
     - `planMembership` / `planByPlaceId` が該当分クリアされる
     - プランが 0 件なら右上の「旅行プラン」ボタンが未所持状態（バッジ無し）になる
4. **回帰確認**
   - プラン内並べ替え（D&D）→ 完了後に順序が保存される
   - お気に入り（行きたい場所リスト）
