### PR TITLE
fix(ui): prevent iOS Safari auto-zoom by enforcing 16px on form fields

### DIFF
--- a/front/src/components/SearchBar.jsx
+++ b/front/src/components/SearchBar.jsx
@@ -112,6 +112,7 @@ function SearchBar({
             maxWidth: "100%",
             boxSizing: "border-box",
             padding: "12px 16px",
+            fontSize: 16,
             borderRadius: 9999,
             border: "1px solid #cfd5d9",
             outline: "none",

--- a/front/src/components/TravelPlanModal.jsx
+++ b/front/src/components/TravelPlanModal.jsx
@@ -235,7 +235,7 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
             <select
               value={selectedPlanId ?? ""}
               onChange={handleSelectChange}
-              style={{ width: "100%", border: "1px solid #eee", borderRadius: 10, padding: "10px" }}
+              style={{ width: "100%", border: "1px solid #eee", borderRadius: 10, padding: "10px", fontSize: 16 }}
               aria-label="旅行プランの選択"
             >
               <option value={NEW_VALUE}>＋ 新しいプランを作成…</option>
@@ -263,7 +263,7 @@ export default function TravelPlanModal({ place, onClose, onAdded }) {
               onChange={(e) => setNewPlanName(e.target.value)}
               placeholder="新しいプラン名を入力"
               aria-label="新しいプラン名"
-              style={{ flex: 1, border: "1px solid #ddd", borderRadius: 8, padding: "8px 10px" }}
+              style={{ flex: 1, border: "1px solid #ddd", borderRadius: 8, padding: "8px 10px", fontSize: 16 }}
             />
             <button
               type="button"


### PR DESCRIPTION
## 概要
iOS Safariでフォーム要素のフォントサイズが16px未満の場合、フォーカス時に画面が自動的にズームされる挙動を修正。  

## 変更内容
- `front/src/components/SearchBar.jsx`
  - 検索入力 `<input>` に `fontSize: 16` を追加
- `front/src/components/TravelPlanModal.jsx`
  - プラン選択 `<select>` に `fontSize: 16` を追加
  - 新規プラン名入力 `<input>` に `fontSize: 16` を追加
