### PR TITLE
fix(ios): prevent Safari auto-zoom by enforcing 16px on form controlsglobally

### DIFF
--- a/front/src/App.css
+++ b/front/src/App.css
@@ -11,6 +11,25 @@ html, body, #root {
   height: 100%;
 }
 
+html {
+  -webkit-text-size-adjust: 100%;
+}
+
+input, select, textarea, button {
+  font-size: 16px;
+  line-height: 1.2;
+}
+
+@supports (-webkit-touch-callout: none) {
+  input, select, textarea, button {
+    font-size: 16px;
+  }
+}
+
+input[type="search"] {
+  -webkit-appearance: none;
+}
+
 #root {
   width: 100%;
   margin: 0;


### PR DESCRIPTION
## 概要
iOS Safari で入力欄フォーカス時にページが自動ズームされる問題を抑止するため、
**フォーム要素のフォントサイズを16px以上に統一**。

## 変更内容
- `front/src/App.css`
  - `html { -webkit-text-size-adjust: 100%; }` を追加
  - `input, select, textarea, button { font-size: 16px; line-height: 1.2; }` を追加
  - iOS向けの @supports ハック、および `input[type="search"]` の見た目調整（任意）を追加
