### PR TITLE
feat(maintenance): purge unregistered users older than 7 days

### DIFF
--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -1,8 +1,15 @@
 class User < ApplicationRecord
   has_one :user_credential, dependent: :destroy
   has_one :user_visit, dependent: :destroy
+  has_many :travel_plans, dependent: :destroy
+  has_many :wishlists, dependent: :destroy
 
   def registered?
     user_credential.present?
   end
+
+  scope :unregistered, -> { left_joins(:user_credential).where(user_credentials: { id: nil }) }
+  scope :expired_guests, ->(cutoff = Time.zone.now - 7.days) {
+    unregistered.where('users.created_at < ?', cutoff)
+  }
 end

--- a/api/config/application.rb
+++ b/api/config/application.rb
@@ -1,7 +1,6 @@
 require_relative "boot"
 
 require "rails"
-# Pick the frameworks you want:
 require "active_model/railtie"
 require "active_job/railtie"
 require "active_record/railtie"
@@ -14,31 +13,16 @@ require "action_view/railtie"
 require "action_cable/engine"
 # require "rails/test_unit/railtie"
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module App
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 
-    # Please, add to the `ignore` list any other `lib` subdirectories that do
-    # not contain `.rb` files, or that should not be reloaded or eager loaded.
-    # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+    config.time_zone = "Tokyo"
+    config.active_record.default_timezone = :utc
 
-    # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
-
-    # Only loads a smaller set of middleware suitable for API only apps.
-    # Middleware like session, flash, cookies can be added back manually.
-    # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
   end
 end

--- a/api/db/migrate/20251017121748_add_index_on_users_created_at.rb
+++ b/api/db/migrate/20251017121748_add_index_on_users_created_at.rb
@@ -1,0 +1,5 @@
+class AddIndexOnUsersCreatedAt < ActiveRecord::Migration[8.0]
+  def change
+    add_index :users, :created_at, if_not_exists: true
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_17_121748) do
   create_table "places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "address", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
     t.index ["place_id"], name: "index_places_on_place_id", unique: true
   end
 
-  create_table "travel_plan_items", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "travel_plan_items", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "travel_plan_id", null: false
     t.bigint "place_id", null: false
     t.integer "sort_order", default: 0, null: false
@@ -34,7 +34,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
     t.index ["travel_plan_id"], name: "index_travel_plan_items_on_travel_plan_id"
   end
 
-  create_table "travel_plans", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "travel_plans", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "name", limit: 100, null: false
     t.datetime "created_at", null: false
@@ -43,7 +43,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
     t.index ["user_id"], name: "index_travel_plans_on_user_id"
   end
 
-  create_table "user_credentials", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_credentials", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "email", null: false
     t.string "password_digest", limit: 60, null: false
@@ -53,7 +53,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
     t.index ["user_id"], name: "index_user_credentials_on_user_id", unique: true
   end
 
-  create_table "user_visits", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_visits", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "token", limit: 36, null: false
     t.datetime "created_at", null: false
@@ -61,9 +61,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
     t.index ["user_id"], name: "index_user_visits_on_user_id", unique: true
   end
 
-  create_table "users", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_users_on_created_at"
   end
 
   create_table "video_view_places", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -86,7 +87,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_04_161709) do
     t.index ["youtube_video_id"], name: "index_video_views_on_youtube_video_id", unique: true
   end
 
-  create_table "wishlists", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "wishlists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "place_id", null: false
     t.datetime "created_at", null: false

--- a/api/lib/tasks/cleanup_guest_users.rake
+++ b/api/lib/tasks/cleanup_guest_users.rake
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+namespace :maintenance do
+  desc 'Delete unregistered users older than 7 days (and their dependents)'
+  task cleanup_guest_users: :environment do
+    cutoff = Time.zone.now - 7.days
+
+    scope = User.left_joins(:user_credential)
+                .where(user_credentials: { id: nil })
+                .where('users.created_at < ?', cutoff)
+
+    dry_run = ENV['DRY_RUN'] == '1'
+    limit   = (ENV['LIMIT'] || 2000).to_i
+
+    total = scope.count
+    puts "[cleanup_guest_users] cutoff=#{cutoff} total_targets=#{total} DRY_RUN=#{dry_run}"
+
+    if dry_run
+      sample_ids = scope.limit(limit).pluck(:id, :created_at)
+      puts "[cleanup_guest_users] sample(#{sample_ids.size}) id, created_at:"
+      sample_ids.each { |id, t| puts "  #{id}, #{t}" }
+      next
+    end
+
+    deleted = 0
+    scope.find_in_batches(batch_size: 1000) do |users|
+      users.each do |u|
+        begin
+          u.destroy!
+          deleted += 1
+        rescue => e
+          warn "[cleanup_guest_users] failed user_id=#{u.id}: #{e.class}: #{e.message}"
+        end
+      end
+    end
+
+    puts "[cleanup_guest_users] deleted=#{deleted}/#{total}"
+  end
+end


### PR DESCRIPTION
## 概要
- 「ゲストログインのみのユーザーは7日間だけデータを保持」の仕様に合わせ、  
  **UserCredentialに紐づかないユーザー**で**作成から7日を超えたもの**を定期的に削除するバッチを追加。
- 連鎖削除のため、User配下の **wishlists / travel_plans（および travel_plan_items）** も合わせて削除。

## 変更内容
- `app/models/user.rb`
  - 連鎖削除: `has_many :travel_plans, dependent: :destroy` / `has_many :wishlists, dependent: :destroy`
  - スコープ追加: `unregistered`, `expired_guests(cutoff = Time.zone.now - 7.days)`
- `lib/tasks/cleanup_guest_users.rake`
  - Rakeタスク: `maintenance:cleanup_guest_users`
  - 環境変数 `DRY_RUN=1` で対象件数・サンプルIDのみ出力（削除はしない）
  - バッチ削除は `destroy!` により Rails の `dependent: :destroy` を実行
- `config/application.rb`
  - `config.time_zone = 'Tokyo'`
  - `config.active_record.default_timezone = :utc`（DBはUTCで保存）
- `db/migrate/*_add_index_on_users_created_at.rb`
  - `users.created_at` にインデックス追加（期限判定の高速化）
- `db/schema.rb` 更新
